### PR TITLE
Feature/20 주요기능 목록상세페이지 편집기능 추가

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -61,6 +61,7 @@
     "@typescript-eslint/no-misused-promises": [
       "error",
       { "checksVoidReturn": { "attributes": false } }
-    ]
+    ],
+    "@typescript-eslint/no-floating-promises": "off"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "react-intersection-observer": "^9.13.1",
         "tailwind-merge": "^2.5.4",
         "tailwindcss-animate": "^1.0.7",
+        "vaul": "^1.1.0",
         "zod": "^3.23.8",
         "zustand": "^5.0.0-rc.2"
       },
@@ -7936,6 +7937,19 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/vaul": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/vaul/-/vaul-1.1.0.tgz",
+      "integrity": "sha512-YhO/bikcauk48hzhMhvIvT+U87cuCbNbKk9fF4Ou5UkI9t2KkBMernmdP37pCzF15hrv55fcny1YhexK8h6GVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-dialog": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
       }
     },
     "node_modules/wheel-gestures": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^3.9.0",
+        "@radix-ui/react-dialog": "^1.1.2",
         "@radix-ui/react-popover": "^1.1.2",
         "@radix-ui/react-slot": "^1.1.0",
         "@radix-ui/react-toast": "^1.2.2",
@@ -1116,6 +1117,42 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.2.tgz",
+      "integrity": "sha512-Yj4dZtqa2o+kG61fzB0H2qUvmwBA2oyQroGLyNtBj1beo1khoQ3q1a2AO8rrQYjd8256CO9+N8L9tvsS+bnIyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.1",
+        "@radix-ui/react-focus-guards": "1.1.1",
+        "@radix-ui/react-focus-scope": "1.1.0",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-portal": "1.1.2",
+        "@radix-ui/react-presence": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-slot": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "aria-hidden": "^1.1.1",
+        "react-remove-scroll": "2.6.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "react-hook-form": "^7.53.0",
         "react-intersection-observer": "^9.13.1",
         "tailwind-merge": "^2.5.4",
+        "tailwind-scrollbar-hide": "^1.1.7",
         "tailwindcss-animate": "^1.0.7",
         "vaul": "^1.1.0",
         "zod": "^3.23.8",
@@ -7577,6 +7578,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/dcastil"
       }
+    },
+    "node_modules/tailwind-scrollbar-hide": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/tailwind-scrollbar-hide/-/tailwind-scrollbar-hide-1.1.7.tgz",
+      "integrity": "sha512-X324n9OtpTmOMqEgDUEA/RgLrNfBF/jwJdctaPZDzB3mppxJk7TLIDmOreEDm1Bq4R9LSPu4Epf8VSdovNU+iA==",
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "3.4.13",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "react-hook-form": "^7.53.0",
     "react-intersection-observer": "^9.13.1",
     "tailwind-merge": "^2.5.4",
+    "tailwind-scrollbar-hide": "^1.1.7",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^1.1.0",
     "zod": "^3.23.8",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
+    "@radix-ui/react-dialog": "^1.1.2",
     "@radix-ui/react-popover": "^1.1.2",
     "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-toast": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "react-intersection-observer": "^9.13.1",
     "tailwind-merge": "^2.5.4",
     "tailwindcss-animate": "^1.0.7",
+    "vaul": "^1.1.0",
     "zod": "^3.23.8",
     "zustand": "^5.0.0-rc.2"
   },

--- a/src/apis/comments.api.ts
+++ b/src/apis/comments.api.ts
@@ -1,0 +1,52 @@
+/* eslint-disable max-len */
+import {
+  AddCommentRequest,
+  DeleteCommentRequest,
+  GetCommentsRequest,
+  UpdateCommentRequest,
+} from '@/types/dto/requests/comment.request.types';
+import {
+  AddCommentResponse,
+  DeleteCommentResponse,
+  GetCommentsResponse,
+  UpdateCommentResponse,
+} from '@/types/dto/responses/comment.request.types';
+import { axiosInstance } from './_axiosInstance';
+
+export const getComments = async (params: GetCommentsRequest) => {
+  const response = await axiosInstance<GetCommentsResponse>({
+    method: 'GET',
+    url: `/tasks/${params.taskId}/comments`,
+  });
+  return response.data;
+};
+
+export const addComment = async (params: AddCommentRequest) => {
+  const response = await axiosInstance<AddCommentResponse>({
+    method: 'POST',
+    url: `/tasks/${params.taskId}/comments`,
+    data: {
+      content: params.content,
+    },
+  });
+  return response.data;
+};
+
+export const updateComment = async (params: UpdateCommentRequest) => {
+  const response = await axiosInstance<UpdateCommentResponse>({
+    method: 'PATCH',
+    url: `/tasks/${params.taskId}/comments/${params.commentId}`,
+    data: {
+      content: params.content,
+    },
+  });
+  return response.data;
+};
+
+export const deleteComment = async (params: DeleteCommentRequest) => {
+  const response = await axiosInstance<DeleteCommentResponse>({
+    method: 'DELETE',
+    url: `/tasks/${params.taskId}/comments/${params.commentId}`,
+  });
+  return response.data;
+};

--- a/src/apis/tasks.api.ts
+++ b/src/apis/tasks.api.ts
@@ -3,11 +3,13 @@ import {
   AddTaskRequest,
   DeleteTaskRequest,
   GetTaskRequest,
+  UpdateTaskRequest,
   UpdateTaskStatusRequest,
 } from '@/types/dto/requests/tasks.request.types';
 import {
   AddTaskResponse,
   GetTaskResponse,
+  UpdateTaskResponse,
   UpdateTaskStatusResponse,
 } from '@/types/dto/responses/tasks.response.types';
 import _ from 'lodash';
@@ -43,6 +45,18 @@ export const updateTaskStatus = async (params: UpdateTaskStatusRequest) => {
 		/task-lists/${params.taskListId}/tasks/${params.taskId}`,
     data: {
       done: params.done,
+    },
+  });
+  return response.data;
+};
+
+export const updateTask = async (params: UpdateTaskRequest) => {
+  const response = await axiosInstance<UpdateTaskResponse>({
+    method: 'PATCH',
+    url: `/groups/${params.groupId}/task-lists/${params.taskListId}/tasks/${params.taskId}`,
+    data: {
+      name: params.name,
+      description: params.description,
     },
   });
   return response.data;

--- a/src/apis/tasks.api.ts
+++ b/src/apis/tasks.api.ts
@@ -2,12 +2,14 @@
 import {
   AddTaskRequest,
   DeleteTaskRequest,
+  GetTaskDetailRequest,
   GetTaskRequest,
   UpdateTaskRequest,
   UpdateTaskStatusRequest,
 } from '@/types/dto/requests/tasks.request.types';
 import {
   AddTaskResponse,
+  GetTaskDetailResponse,
   GetTaskResponse,
   UpdateTaskResponse,
   UpdateTaskStatusResponse,
@@ -22,6 +24,14 @@ export const getTask = async (params: GetTaskRequest) => {
     params: {
       date: params.date,
     },
+  });
+  return response.data;
+};
+
+export const getTaskDetail = async (params: GetTaskDetailRequest) => {
+  const response = await axiosInstance<GetTaskDetailResponse>({
+    method: 'GET',
+    url: `/groups/${params.groupId}/task-lists/${params.taskListId}/tasks/${params.taskId}`,
   });
   return response.data;
 };

--- a/src/apis/tasks.api.ts
+++ b/src/apis/tasks.api.ts
@@ -1,5 +1,7 @@
+/* eslint-disable max-len */
 import {
   AddTaskRequest,
+  DeleteTaskRequest,
   GetTaskRequest,
   UpdateTaskStatusRequest,
 } from '@/types/dto/requests/tasks.request.types';
@@ -44,4 +46,11 @@ export const updateTaskStatus = async (params: UpdateTaskStatusRequest) => {
     },
   });
   return response.data;
+};
+
+export const deleteTask = async (params: DeleteTaskRequest) => {
+  await axiosInstance({
+    method: 'DELETE',
+    url: `/groups/${params.groupId}/task-lists/${params.taskListId}/tasks/${params.taskId}`,
+  });
 };

--- a/src/apis/users.api.ts
+++ b/src/apis/users.api.ts
@@ -1,6 +1,12 @@
 import {
+  ResetPasswordRequest,
+  SendResetPasswordEmailRequest,
+} from '@/types/dto/requests/users.request.types';
+import {
   GetMembershipsResponse,
   GetUserResponse,
+  ResetPasswordResponse,
+  SendResetPasswordEmailResponse,
 } from '@/types/dto/responses/users.response.types';
 import { axiosInstance } from './_axiosInstance';
 
@@ -16,6 +22,26 @@ export const getMemberships = async () => {
   const response = await axiosInstance<GetMembershipsResponse>({
     method: 'GET',
     url: '/user/memberships',
+  });
+  return response.data;
+};
+
+export const sendResetPasswordEmail = async (
+  params: SendResetPasswordEmailRequest
+) => {
+  const response = await axiosInstance<SendResetPasswordEmailResponse>({
+    method: 'POST',
+    url: '/user/send-reset-password-email',
+    data: params,
+  });
+  return response.data;
+};
+
+export const resetPassword = async (params: ResetPasswordRequest) => {
+  const response = await axiosInstance<ResetPasswordResponse>({
+    method: 'PATCH',
+    url: '/user/reset-password',
+    data: params,
   });
   return response.data;
 };

--- a/src/components/auth/resetPassword/SendResetPasswordForm.tsx
+++ b/src/components/auth/resetPassword/SendResetPasswordForm.tsx
@@ -1,0 +1,80 @@
+/* eslint-disable max-len */
+import Button, {
+  ButtonBackgroundColor,
+  ButtonBorderColor,
+  ButtonPadding,
+  ButtonStyle,
+  ButtonWidth,
+  TextColor,
+  TextSize,
+} from '@/components/common/Button/Button';
+import Input from '@/components/common/Input';
+import { useModalContext } from '@/components/modal/model/modal.context';
+import { sendResetPasswordSchema } from '@/constants/formSchemas/authSchema';
+import { useSendResetPasswordEmail } from '@/queries/users.queries';
+import { SendResetPasswordEmailRequest } from '@/types/dto/requests/users.request.types';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { LoaderIcon } from 'lucide-react';
+import { useForm } from 'react-hook-form';
+
+function SendResetPasswordForm() {
+  const { mutate: sendResetPassword, isPending } = useSendResetPasswordEmail();
+  const { toggle } = useModalContext();
+
+  const { register, handleSubmit } = useForm<SendResetPasswordEmailRequest>({
+    mode: 'onBlur',
+    resolver: zodResolver(sendResetPasswordSchema),
+  });
+
+  const onSubmit = (data: SendResetPasswordEmailRequest) => {
+    data.redirectUrl =
+      process.env.NEXT_PUBLIC_RESET_PASSWORD_REDIRECT_URL || '';
+    sendResetPassword(data, {
+      onSuccess: () => {
+        toggle();
+      },
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <Input
+        type="email"
+        id="email-input"
+        placeholder="이메일을 입력해주세요."
+        {...register('email')}
+      />
+      <div className="mt-4 flex justify-center gap-2">
+        <Button
+          type="button"
+          className="text-brand-primary"
+          buttonStyle={ButtonStyle.Box}
+          buttonWidth={ButtonWidth.Full}
+          textSize={TextSize.Medium}
+          textColor={TextColor.Green}
+          buttonBackgroundColor={ButtonBackgroundColor.White}
+          buttonBorderColor={ButtonBorderColor.Green}
+          buttonPadding={ButtonPadding.Medium}
+          onClick={toggle}
+        >
+          닫기
+        </Button>
+        <Button
+          type="submit"
+          buttonStyle={ButtonStyle.Box}
+          buttonWidth={ButtonWidth.Full}
+          textSize={TextSize.Medium}
+          textColor={TextColor.White}
+          buttonBackgroundColor={ButtonBackgroundColor.Green}
+          buttonBorderColor={ButtonBorderColor.Green}
+          buttonPadding={ButtonPadding.Medium}
+          disabled={isPending}
+        >
+          {isPending ? <LoaderIcon className="animate-spin" /> : '링크 보내기'}
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+export default SendResetPasswordForm;

--- a/src/components/auth/signin/SignInForm.tsx
+++ b/src/components/auth/signin/SignInForm.tsx
@@ -8,26 +8,14 @@ import Button, {
   TextSize,
 } from '@/components/common/Button/Button';
 import Input from '@/components/common/Input';
+import { signInSchema } from '@/constants/formSchemas/authSchema';
 import { useSignIn } from '@/queries/auth.queries';
 import { useAuthStore } from '@/store/useAuthStore';
 import { SignInRequest } from '@/types/dto/requests/auth.request.types';
 import { zodResolver } from '@hookform/resolvers/zod';
-import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
-import { z } from 'zod';
-
-const schema = z.object({
-  email: z
-    .string()
-    .min(1, '이메일은 필수 입력입니다.')
-    .email('이메일 형식으로 작성해 주세요.'),
-  password: z
-    .string()
-    .min(1, '비밀번호는 필수 입력입니다.')
-    .min(8, '비밀번호는 최소 8자 이상이어야 합니다.'),
-});
 
 type SignInError = {
   response?: {
@@ -61,7 +49,7 @@ function SignInForm() {
       email: '',
       password: '',
     },
-    resolver: zodResolver(schema),
+    resolver: zodResolver(signInSchema),
   });
 
   const onSubmit = (data: SignInRequest) => {
@@ -120,12 +108,6 @@ function SignInForm() {
       >
         로그인
       </Button>
-      <div className="flex justify-center gap-2 text-lg-medium text-primary">
-        <p>아직 계정이 없으신가요?</p>
-        <Link className="text-interaction-focus underline" href="/signup">
-          가입하기
-        </Link>
-      </div>
     </form>
   );
 }

--- a/src/components/auth/signin/SignInSection.tsx
+++ b/src/components/auth/signin/SignInSection.tsx
@@ -1,10 +1,14 @@
+import { Modal } from '@/components/modal';
+import { cn } from '@/utils/tailwind/cn';
+import Link from 'next/link';
+import SendResetPasswordForm from '../resetPassword/SendResetPasswordForm';
 import SignInForm from './SignInForm';
 
 function SignInSection() {
   return (
     <section
       className="mt-[8.75rem] flex w-full max-w-[28.75rem] flex-col
-								items-center tab:mt-[6.25rem] mob:mt-[1.5rem] "
+								items-center tab:mt-[6.25rem] mob:mt-[1.5rem]"
     >
       <div
         className="mb-20 font-pretendard text-4xl 
@@ -14,6 +18,38 @@ function SignInSection() {
         로그인
       </div>
       <SignInForm />
+      <div
+        className={cn(
+          'mt-6 flex justify-center gap-2 text-lg-medium text-primary'
+        )}
+      >
+        <p>아직 계정이 없으신가요?</p>
+        <Link className="text-interaction-focus underline" href="/signup">
+          가입하기
+        </Link>
+      </div>
+
+      <Modal>
+        <Modal.Toggle className="mt-2">
+          <span className={cn('text-lg-semibold text-brand-primary underline')}>
+            비밀번호를 잊으셨나요?
+          </span>
+        </Modal.Toggle>
+        <Modal.Portal>
+          <Modal.Overlay />
+          <Modal.Content withToggle>
+            <Modal.Header>
+              <Modal.Title>비밀번호 재설정</Modal.Title>
+              <Modal.Summary className="text-md-medium text-default">
+                비밀번호 재설정 링크를 보내드립니다.
+              </Modal.Summary>
+            </Modal.Header>
+            <Modal.Body className="mt-4 w-[18rem]">
+              <SendResetPasswordForm />
+            </Modal.Body>
+          </Modal.Content>
+        </Modal.Portal>
+      </Modal>
     </section>
   );
 }

--- a/src/components/auth/signup/SignUpForm.tsx
+++ b/src/components/auth/signup/SignUpForm.tsx
@@ -8,41 +8,13 @@ import Button, {
   TextSize,
 } from '@/components/common/Button/Button';
 import Input from '@/components/common/Input';
+import { signUpSchema } from '@/constants/formSchemas/authSchema';
 import { useSignIn, useSignUp } from '@/queries/auth.queries';
 import { SignUpRequest } from '@/types/dto/requests/auth.request.types';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
-import { z } from 'zod';
-
-const schema = z
-  .object({
-    nickname: z
-      .string()
-      .min(1, '닉네임은 필수 입력입니다.')
-      .max(20, '닉네임은 최대 20자까지 가능합니다.'),
-    email: z
-      .string()
-      .min(1, '이메일은 필수 입력입니다.')
-      .email('이메일 형식으로 작성해 주세요.'),
-    password: z
-      .string()
-      .min(1, '비밀번호는 필수 입력입니다.')
-      .min(8, '비밀번호는 최소 8자 이상이어야 합니다.')
-      .regex(
-        /^[A-Za-z0-9!@#$%^&*]+$/,
-        '비밀번호는 숫자, 영문, 특수문자로만 가능합니다.'
-      ),
-    passwordConfirmation: z
-      .string()
-      .min(1, '비밀번호 확인은 필수 입력입니다.')
-      .min(8, '비밀번호는 최소 8자 이상이어야 합니다.'),
-  })
-  .refine((data) => data.password === data.passwordConfirmation, {
-    message: '비밀번호가 일치하지 않습니다.',
-    path: ['passwordConfirmation'],
-  });
 
 type SignUpError = {
   response?: {
@@ -76,7 +48,7 @@ function SignUpForm() {
       password: '',
       passwordConfirmation: '',
     },
-    resolver: zodResolver(schema),
+    resolver: zodResolver(signUpSchema),
   });
 
   const onSubmit = (data: SignUpRequest) => {

--- a/src/components/common/Avatar.tsx
+++ b/src/components/common/Avatar.tsx
@@ -1,0 +1,34 @@
+import { cn } from '@/utils/tailwind/cn';
+import Image from 'next/image';
+import { forwardRef } from 'react';
+
+type AvatarProps = React.HTMLAttributes<HTMLDivElement> & {
+  src: string | null;
+  userNickname?: string;
+  nicknameClassName?: string;
+};
+
+const Avatar = forwardRef<HTMLDivElement, AvatarProps>(
+  ({ className, src, userNickname, nicknameClassName, ...props }, ref) => {
+    const imageSrc = src ?? '/icons/Member.svg';
+    return (
+      <div className={cn('flex items-center gap-3', className)} {...props}>
+        <div ref={ref} className={cn('rounded-full')}>
+          <Image
+            src={imageSrc}
+            alt="유저 프로필 이미지"
+            width={40}
+            height={40}
+          />
+        </div>
+        {userNickname && (
+          <p className={cn('text-md-medium text-primary', nicknameClassName)}>
+            {userNickname}
+          </p>
+        )}
+      </div>
+    );
+  }
+);
+
+export default Avatar;

--- a/src/components/common/CheckableText.tsx
+++ b/src/components/common/CheckableText.tsx
@@ -8,11 +8,14 @@ type CheckableTextProps = {
 
 function CheckableText({ children, isChecked, onChange }: CheckableTextProps) {
   return (
-    <div className="flex items-center rounded-lg bg-gray-800 p-2.5">
+    <div className="flex items-center rounded-lg bg-transparent p-2.5">
       <input
         type="checkbox"
         checked={isChecked}
         onChange={onChange}
+        onClick={(e: React.MouseEvent<HTMLInputElement>) => {
+          e.stopPropagation();
+        }}
         className={cn(
           'h-5 w-5 cursor-pointer appearance-none rounded-md',
           'border-2 border-icon-inverse',

--- a/src/components/common/DatePicker.tsx
+++ b/src/components/common/DatePicker.tsx
@@ -155,7 +155,7 @@ export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(
         {mode === 'input' && (
           <input
             type="text"
-            value={date?.toISOString()}
+            value={date?.toLocaleDateString('ko-KR')}
             className="hidden"
             ref={ref}
             suppressHydrationWarning

--- a/src/components/common/DatePickerInput.tsx
+++ b/src/components/common/DatePickerInput.tsx
@@ -21,7 +21,7 @@ const DatePickerInput = forwardRef<HTMLInputElement, DatePickerInputProps>(
           initialDate={initialDate}
           popoverContentClassName="border-[1px] border-green-400"
           onDateChange={(date) => {
-            formContext.setValue('startDate', date.toISOString());
+            formContext.setValue('startDate', date.toLocaleDateString('ko-KR'));
           }}
           ref={ref as React.LegacyRef<HTMLInputElement>}
         />

--- a/src/components/common/Dialog.tsx
+++ b/src/components/common/Dialog.tsx
@@ -47,6 +47,7 @@ const DialogContent = forwardRef<
         'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg',
         'translate-x-[-50%] translate-y-[-50%] gap-4 border',
         'border-primary bg-secondary p-6 shadow-lg duration-200',
+        'scrollbar-hide hover:scrollbar-default',
         'rounded-2xl',
         className
       )}

--- a/src/components/common/Dialog.tsx
+++ b/src/components/common/Dialog.tsx
@@ -46,8 +46,8 @@ const DialogContent = forwardRef<
         'data-[state=open]:slide-in-from-top-[48%]',
         'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg',
         'translate-x-[-50%] translate-y-[-50%] gap-4 border',
-        'border-neutral-200 bg-white p-6 shadow-lg duration-200',
-        'sm:rounded-lg dark:border-neutral-800 dark:bg-neutral-950',
+        'border-primary bg-secondary p-6 shadow-lg duration-200',
+        'sm:rounded-lg',
         className
       )}
       {...props}
@@ -55,13 +55,12 @@ const DialogContent = forwardRef<
       {children}
       <DialogPrimitive.Close
         className={cn(
-          'absolute right-4 top-4 rounded-sm opacity-70 ring-offset-white',
+          'absolute right-4 top-4 rounded-sm',
+          'opacity-70 ring-offset-icon-inverse',
           'transition-opacity hover:opacity-100 focus:outline-none',
-          'focus:ring-2 focus:ring-neutral-950 focus:ring-offset-2',
+          'focus:ring-2 focus:ring-background-primary focus:ring-offset-2',
           'disabled:pointer-events-none data-[state=open]:bg-neutral-100',
-          'data-[state=open]:text-neutral-500 dark:ring-offset-neutral-950',
-          'dark:focus:ring-neutral-300 dark:data-[state=open]:bg-neutral-800',
-          'dark:data-[state=open]:text-neutral-400'
+          'data-[state=open]:text-neutral-500'
         )}
       >
         <X className="h-4 w-4" />

--- a/src/components/common/Dialog.tsx
+++ b/src/components/common/Dialog.tsx
@@ -47,7 +47,7 @@ const DialogContent = forwardRef<
         'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg',
         'translate-x-[-50%] translate-y-[-50%] gap-4 border',
         'border-primary bg-secondary p-6 shadow-lg duration-200',
-        'sm:rounded-lg',
+        'rounded-2xl',
         className
       )}
       {...props}

--- a/src/components/common/Dialog.tsx
+++ b/src/components/common/Dialog.tsx
@@ -1,0 +1,145 @@
+import { cn } from '@/utils/tailwind/cn';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { X } from 'lucide-react';
+import * as React from 'react';
+
+const Dialog = DialogPrimitive.Root;
+
+const DialogTrigger = DialogPrimitive.Trigger;
+
+const DialogPortal = DialogPrimitive.Portal;
+
+const DialogClose = DialogPrimitive.Close;
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      'data-[state=open]:animate-in data-[state=closed]:animate-out',
+      'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      'fixed inset-0 z-50 bg-black/80',
+      className
+    )}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'data-[state=open]:animate-in data-[state=closed]:animate-out',
+        'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+        'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
+        'data-[state=closed]:slide-out-to-left-1/2',
+        'data-[state=closed]:slide-out-to-top-[48%]',
+        'data-[state=open]:slide-in-from-left-1/2',
+        'data-[state=open]:slide-in-from-top-[48%]',
+        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg',
+        'translate-x-[-50%] translate-y-[-50%] gap-4 border',
+        'border-neutral-200 bg-white p-6 shadow-lg duration-200',
+        'sm:rounded-lg dark:border-neutral-800 dark:bg-neutral-950',
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close
+        className={cn(
+          'absolute right-4 top-4 rounded-sm opacity-70 ring-offset-white',
+          'transition-opacity hover:opacity-100 focus:outline-none',
+          'focus:ring-2 focus:ring-neutral-950 focus:ring-offset-2',
+          'disabled:pointer-events-none data-[state=open]:bg-neutral-100',
+          'data-[state=open]:text-neutral-500 dark:ring-offset-neutral-950',
+          'dark:focus:ring-neutral-300 dark:data-[state=open]:bg-neutral-800',
+          'dark:data-[state=open]:text-neutral-400'
+        )}
+      >
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+function DialogHeader({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn(
+        'flex flex-col space-y-1.5 text-center sm:text-left',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+DialogHeader.displayName = 'DialogHeader';
+
+function DialogFooter({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn(
+        'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+DialogFooter.displayName = 'DialogFooter';
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn(
+      'text-lg font-semibold leading-none tracking-tight',
+      className
+    )}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn('text-sm text-neutral-500 dark:text-neutral-400', className)}
+    {...props}
+  />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+};

--- a/src/components/common/Dialog.tsx
+++ b/src/components/common/Dialog.tsx
@@ -1,7 +1,7 @@
 import { cn } from '@/utils/tailwind/cn';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { X } from 'lucide-react';
-import * as React from 'react';
+import { ComponentPropsWithoutRef, ElementRef, forwardRef } from 'react';
 
 const Dialog = DialogPrimitive.Root;
 
@@ -11,7 +11,7 @@ const DialogPortal = DialogPrimitive.Portal;
 
 const DialogClose = DialogPrimitive.Close;
 
-const DialogOverlay = React.forwardRef<
+const DialogOverlay = forwardRef<
   React.ElementRef<typeof DialogPrimitive.Overlay>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
 >(({ className, ...props }, ref) => (
@@ -28,9 +28,9 @@ const DialogOverlay = React.forwardRef<
 ));
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
-const DialogContent = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+const DialogContent = forwardRef<
+  ElementRef<typeof DialogPrimitive.Content>,
+  ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
 >(({ className, children, ...props }, ref) => (
   <DialogPortal>
     <DialogOverlay />
@@ -104,7 +104,7 @@ function DialogFooter({
 }
 DialogFooter.displayName = 'DialogFooter';
 
-const DialogTitle = React.forwardRef<
+const DialogTitle = forwardRef<
   React.ElementRef<typeof DialogPrimitive.Title>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
 >(({ className, ...props }, ref) => (
@@ -119,9 +119,9 @@ const DialogTitle = React.forwardRef<
 ));
 DialogTitle.displayName = DialogPrimitive.Title.displayName;
 
-const DialogDescription = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Description>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+const DialogDescription = forwardRef<
+  ElementRef<typeof DialogPrimitive.Description>,
+  ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Description
     ref={ref}

--- a/src/components/common/Divider.tsx
+++ b/src/components/common/Divider.tsx
@@ -1,0 +1,19 @@
+import { cn } from '@/utils/tailwind/cn';
+import { ComponentPropsWithoutRef, ElementRef, forwardRef } from 'react';
+
+type DividerProps = ComponentPropsWithoutRef<'hr'> & {
+  orientation?: 'horizontal' | 'vertical';
+};
+
+export const Divider = forwardRef<ElementRef<'hr'>, DividerProps>(
+  ({ className, orientation = 'horizontal', ...props }, ref) => (
+    <hr
+      ref={ref}
+      className={cn('h-px w-full bg-icon-primary', className)}
+      aria-orientation={orientation}
+      {...props}
+    />
+  )
+);
+
+Divider.displayName = 'Divider';

--- a/src/components/common/Drawer.tsx
+++ b/src/components/common/Drawer.tsx
@@ -1,0 +1,127 @@
+import { cn } from '@/utils/tailwind/cn';
+import * as React from 'react';
+import { Drawer as DrawerPrimitive } from 'vaul';
+
+function Drawer({
+  shouldScaleBackground = true,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Root>) {
+  return (
+    <DrawerPrimitive.Root
+      shouldScaleBackground={shouldScaleBackground}
+      {...props}
+    />
+  );
+}
+
+Drawer.displayName = 'Drawer';
+
+const DrawerTrigger = DrawerPrimitive.Trigger;
+
+const DrawerPortal = DrawerPrimitive.Portal;
+
+const DrawerClose = DrawerPrimitive.Close;
+
+const DrawerOverlay = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Overlay
+    ref={ref}
+    className={cn('fixed inset-0 z-50 bg-black/80', className)}
+    {...props}
+  />
+));
+DrawerOverlay.displayName = DrawerPrimitive.Overlay.displayName;
+
+const DrawerContent = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DrawerPortal>
+    <DrawerOverlay />
+    <DrawerPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col',
+        'rounded-t-[10px] border border-neutral-200 bg-white',
+        'dark:border-neutral-800 dark:bg-neutral-950',
+        className
+      )}
+      {...props}
+    >
+      <div
+        className="rounded-full', 'bg-neutral-100 mx-auto mt-4 h-2
+			w-[100px] dark:bg-neutral-800"
+      />
+      {children}
+    </DrawerPrimitive.Content>
+  </DrawerPortal>
+));
+DrawerContent.displayName = 'DrawerContent';
+
+function DrawerHeader({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn('grid gap-1.5 p-4 text-center', 'sm:text-left', className)}
+      {...props}
+    />
+  );
+}
+DrawerHeader.displayName = 'DrawerHeader';
+
+function DrawerFooter({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn('mt-auto flex flex-col gap-2 p-4', className)}
+      {...props}
+    />
+  );
+}
+DrawerFooter.displayName = 'DrawerFooter';
+
+const DrawerTitle = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Title
+    ref={ref}
+    className={cn(
+      'text-lg font-semibold leading-none tracking-tight',
+      className
+    )}
+    {...props}
+  />
+));
+DrawerTitle.displayName = DrawerPrimitive.Title.displayName;
+
+const DrawerDescription = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Description
+    ref={ref}
+    className={cn('text-sm text-neutral-500 dark:text-neutral-400', className)}
+    {...props}
+  />
+));
+DrawerDescription.displayName = DrawerPrimitive.Description.displayName;
+
+export {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerOverlay,
+  DrawerPortal,
+  DrawerTitle,
+  DrawerTrigger,
+};

--- a/src/components/common/Drawer.tsx
+++ b/src/components/common/Drawer.tsx
@@ -44,16 +44,12 @@ const DrawerContent = forwardRef<
       ref={ref}
       className={cn(
         'fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col',
-        'rounded-t-[10px] border border-neutral-200 bg-white',
-        'dark:border-neutral-800 dark:bg-neutral-950',
+        'rounded-t-xl border-none bg-secondary',
         className
       )}
       {...props}
     >
-      <div
-        className="rounded-full', 'bg-neutral-100 mx-auto mt-4 h-2
-			w-[100px] dark:bg-neutral-800"
-      />
+      <div className={cn('bg-icon mx-auto mt-4 h-2 w-[100px] rounded-full')} />
       {children}
     </DrawerPrimitive.Content>
   </DrawerPortal>

--- a/src/components/common/Drawer.tsx
+++ b/src/components/common/Drawer.tsx
@@ -1,5 +1,5 @@
 import { cn } from '@/utils/tailwind/cn';
-import * as React from 'react';
+import { ComponentPropsWithoutRef, ElementRef, forwardRef } from 'react';
 import { Drawer as DrawerPrimitive } from 'vaul';
 
 function Drawer({
@@ -22,9 +22,9 @@ const DrawerPortal = DrawerPrimitive.Portal;
 
 const DrawerClose = DrawerPrimitive.Close;
 
-const DrawerOverlay = React.forwardRef<
-  React.ElementRef<typeof DrawerPrimitive.Overlay>,
-  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Overlay>
+const DrawerOverlay = forwardRef<
+  ElementRef<typeof DrawerPrimitive.Overlay>,
+  ComponentPropsWithoutRef<typeof DrawerPrimitive.Overlay>
 >(({ className, ...props }, ref) => (
   <DrawerPrimitive.Overlay
     ref={ref}
@@ -34,9 +34,9 @@ const DrawerOverlay = React.forwardRef<
 ));
 DrawerOverlay.displayName = DrawerPrimitive.Overlay.displayName;
 
-const DrawerContent = React.forwardRef<
-  React.ElementRef<typeof DrawerPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Content>
+const DrawerContent = forwardRef<
+  ElementRef<typeof DrawerPrimitive.Content>,
+  ComponentPropsWithoutRef<typeof DrawerPrimitive.Content>
 >(({ className, children, ...props }, ref) => (
   <DrawerPortal>
     <DrawerOverlay />
@@ -86,9 +86,9 @@ function DrawerFooter({
 }
 DrawerFooter.displayName = 'DrawerFooter';
 
-const DrawerTitle = React.forwardRef<
-  React.ElementRef<typeof DrawerPrimitive.Title>,
-  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Title>
+const DrawerTitle = forwardRef<
+  ElementRef<typeof DrawerPrimitive.Title>,
+  ComponentPropsWithoutRef<typeof DrawerPrimitive.Title>
 >(({ className, ...props }, ref) => (
   <DrawerPrimitive.Title
     ref={ref}
@@ -101,9 +101,9 @@ const DrawerTitle = React.forwardRef<
 ));
 DrawerTitle.displayName = DrawerPrimitive.Title.displayName;
 
-const DrawerDescription = React.forwardRef<
-  React.ElementRef<typeof DrawerPrimitive.Description>,
-  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Description>
+const DrawerDescription = forwardRef<
+  ElementRef<typeof DrawerPrimitive.Description>,
+  ComponentPropsWithoutRef<typeof DrawerPrimitive.Description>
 >(({ className, ...props }, ref) => (
   <DrawerPrimitive.Description
     ref={ref}

--- a/src/components/common/DrawerDialog.tsx
+++ b/src/components/common/DrawerDialog.tsx
@@ -1,0 +1,72 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/common/Dialog';
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger,
+} from '@/components/common/drawer';
+import { useIsMobile } from '@/hooks/useIsMobile';
+
+type DrawerDialogProps = {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  trigger: React.ReactNode;
+  title?: React.ReactNode;
+  description?: React.ReactNode;
+  content: React.ReactNode;
+  closeButton?: React.ReactNode;
+};
+
+export function DrawerDialog({
+  open,
+  setOpen,
+  trigger,
+  title,
+  description,
+  content,
+  closeButton,
+}: DrawerDialogProps) {
+  const isMobile = useIsMobile();
+
+  if (!isMobile) {
+    return (
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogTrigger asChild>{trigger}</DialogTrigger>
+        <DialogContent className="sm:max-w-[425px]">
+          <DialogHeader>
+            <DialogTitle>{title}</DialogTitle>
+            <DialogDescription>{description}</DialogDescription>
+          </DialogHeader>
+          {content}
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
+  return (
+    <Drawer open={open} onOpenChange={setOpen}>
+      <DrawerTrigger asChild>{trigger}</DrawerTrigger>
+      <DrawerContent>
+        <DrawerHeader className="text-left">
+          <DrawerTitle>{title}</DrawerTitle>
+          <DrawerDescription>{description}</DrawerDescription>
+        </DrawerHeader>
+        {content}
+        <DrawerFooter className="pt-2">
+          <DrawerClose asChild>{closeButton}</DrawerClose>
+        </DrawerFooter>
+      </DrawerContent>
+    </Drawer>
+  );
+}

--- a/src/components/common/DrawerDialog.tsx
+++ b/src/components/common/DrawerDialog.tsx
@@ -55,14 +55,16 @@ export function DrawerDialog({
             dialogClassName
           )}
         >
-          {(title || description) && (
-            <DialogHeader>
-              <DialogTitle>{title}</DialogTitle>
-              {description && (
-                <DialogDescription>{description}</DialogDescription>
-              )}
-            </DialogHeader>
-          )}
+          <DialogHeader
+            className={cn({
+              hidden: !title && !description,
+            })}
+          >
+            <DialogTitle>{title}</DialogTitle>
+            {description && (
+              <DialogDescription>{description}</DialogDescription>
+            )}
+          </DialogHeader>
           {children}
         </DialogContent>
       </Dialog>

--- a/src/components/common/DrawerDialog.tsx
+++ b/src/components/common/DrawerDialog.tsx
@@ -15,16 +15,16 @@ import {
   DrawerHeader,
   DrawerTitle,
   DrawerTrigger,
-} from '@/components/common/drawer';
+} from '@/components/common/Drawer';
 import { useIsMobile } from '@/hooks/useIsMobile';
 
 type DrawerDialogProps = {
   open: boolean;
   setOpen: (open: boolean) => void;
-  trigger: React.ReactNode;
+  trigger?: React.ReactNode;
   title?: React.ReactNode;
   description?: React.ReactNode;
-  content: React.ReactNode;
+  content?: React.ReactNode;
   closeButton?: React.ReactNode;
 };
 
@@ -42,11 +42,13 @@ export function DrawerDialog({
   if (!isMobile) {
     return (
       <Dialog open={open} onOpenChange={setOpen}>
-        <DialogTrigger asChild>{trigger}</DialogTrigger>
+        {trigger && <DialogTrigger asChild>{trigger}</DialogTrigger>}
         <DialogContent className="sm:max-w-[425px]">
           <DialogHeader>
             <DialogTitle>{title}</DialogTitle>
-            <DialogDescription>{description}</DialogDescription>
+            {description && (
+              <DialogDescription>{description}</DialogDescription>
+            )}
           </DialogHeader>
           {content}
         </DialogContent>
@@ -56,15 +58,15 @@ export function DrawerDialog({
 
   return (
     <Drawer open={open} onOpenChange={setOpen}>
-      <DrawerTrigger asChild>{trigger}</DrawerTrigger>
+      {trigger && <DrawerTrigger asChild>{trigger}</DrawerTrigger>}
       <DrawerContent>
         <DrawerHeader className="text-left">
           <DrawerTitle>{title}</DrawerTitle>
-          <DrawerDescription>{description}</DrawerDescription>
+          {description && <DrawerDescription>{description}</DrawerDescription>}
         </DrawerHeader>
         {content}
         <DrawerFooter className="pt-2">
-          <DrawerClose asChild>{closeButton}</DrawerClose>
+          {closeButton && <DrawerClose asChild>{closeButton}</DrawerClose>}
         </DrawerFooter>
       </DrawerContent>
     </Drawer>

--- a/src/components/common/DrawerDialog.tsx
+++ b/src/components/common/DrawerDialog.tsx
@@ -17,6 +17,8 @@ import {
   DrawerTrigger,
 } from '@/components/common/Drawer';
 import { useIsMobile } from '@/hooks/useIsMobile';
+import { cn } from '@/utils/tailwind/cn';
+import React from 'react';
 
 type DrawerDialogProps = {
   open: boolean;
@@ -24,8 +26,9 @@ type DrawerDialogProps = {
   trigger?: React.ReactNode;
   title?: React.ReactNode;
   description?: React.ReactNode;
-  content?: React.ReactNode;
+  children?: React.ReactNode;
   closeButton?: React.ReactNode;
+  dialogClassName?: React.HTMLAttributes<HTMLDivElement>['className'];
 };
 
 export function DrawerDialog({
@@ -34,8 +37,9 @@ export function DrawerDialog({
   trigger,
   title,
   description,
-  content,
+  children,
   closeButton,
+  dialogClassName,
 }: DrawerDialogProps) {
   const isMobile = useIsMobile();
 
@@ -43,14 +47,23 @@ export function DrawerDialog({
     return (
       <Dialog open={open} onOpenChange={setOpen}>
         {trigger && <DialogTrigger asChild>{trigger}</DialogTrigger>}
-        <DialogContent className="sm:max-w-[425px]">
-          <DialogHeader>
-            <DialogTitle>{title}</DialogTitle>
-            {description && (
-              <DialogDescription>{description}</DialogDescription>
-            )}
-          </DialogHeader>
-          {content}
+        <DialogContent
+          className={cn(
+            'mx-auto h-full max-h-[90vh] w-full',
+            'overflow-y-scroll',
+            'max-w-[48rem]',
+            dialogClassName
+          )}
+        >
+          {(title || description) && (
+            <DialogHeader>
+              <DialogTitle>{title}</DialogTitle>
+              {description && (
+                <DialogDescription>{description}</DialogDescription>
+              )}
+            </DialogHeader>
+          )}
+          {children}
         </DialogContent>
       </Dialog>
     );
@@ -60,11 +73,15 @@ export function DrawerDialog({
     <Drawer open={open} onOpenChange={setOpen}>
       {trigger && <DrawerTrigger asChild>{trigger}</DrawerTrigger>}
       <DrawerContent>
-        <DrawerHeader className="text-left">
-          <DrawerTitle>{title}</DrawerTitle>
-          {description && <DrawerDescription>{description}</DrawerDescription>}
-        </DrawerHeader>
-        {content}
+        {(title || description) && (
+          <DrawerHeader className="text-left">
+            <DrawerTitle>{title}</DrawerTitle>
+            {description && (
+              <DrawerDescription>{description}</DrawerDescription>
+            )}
+          </DrawerHeader>
+        )}
+        {children}
         <DrawerFooter className="pt-2">
           {closeButton && <DrawerClose asChild>{closeButton}</DrawerClose>}
         </DrawerFooter>

--- a/src/components/common/IconAndText.tsx
+++ b/src/components/common/IconAndText.tsx
@@ -8,8 +8,8 @@ export default function IconAndText({
 }: {
   icon: React.ReactNode;
   text: string;
-  wrapperClassName?: string;
-  textClassName?: string;
+  wrapperClassName?: React.HTMLAttributes<HTMLDivElement>['className'];
+  textClassName?: React.HTMLAttributes<HTMLSpanElement>['className'];
 }) {
   return (
     <div className={cn('flex items-center gap-1', wrapperClassName)}>

--- a/src/components/task/AddTaskForm.tsx
+++ b/src/components/task/AddTaskForm.tsx
@@ -85,7 +85,7 @@ function AddTaskForm() {
         />
         <DatePickerInput
           label="시작 날짜 및 시간"
-          initialDate={new Date(selectedDate)}
+          initialDate={new Date(selectedDate.toLocaleDateString('ko-KR'))}
           {...methods.register('startDate')}
           errorMessage={methods.formState.errors.startDate?.message}
         />

--- a/src/components/task/TaskCard.tsx
+++ b/src/components/task/TaskCard.tsx
@@ -1,3 +1,5 @@
+import { useDeleteTask } from '@/queries/tasks.queries';
+import { useTaskStore } from '@/store/useTaskStore';
 import { FrequencyType, Task } from '@/types/tasks.types';
 import {
   formatFrequencyToKorean,
@@ -5,13 +7,22 @@ import {
 } from '@/utils/dateTimeUtils/FormatData';
 import { cn } from '@/utils/tailwind/cn';
 import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from '@radix-ui/react-dialog';
+import {
   CalendarClockIcon,
   MessageSquareIcon,
   MoreVerticalIcon,
   RepeatIcon,
 } from 'lucide-react';
 import { forwardRef } from 'react';
+import { Button } from '../common/Button/ShadcnButton';
 import CheckableText from '../common/CheckableText';
+import { DialogFooter, DialogHeader } from '../common/Dialog';
+import Dropdown from '../common/Dropdown';
 
 type TaskCardProps = {
   task: Task;
@@ -21,71 +32,157 @@ type TaskCardProps = {
 
 const TaskCard = forwardRef<HTMLDivElement, TaskCardProps>(
   ({ task, onCheckBoxChange, onClick }, ref) => {
+    const {
+      selectedTaskList,
+      setIsTaskUpdateFormShow,
+      isTaskDeleteDialogOpen,
+      setIsTaskDeleteDialogOpen,
+      selectedDate,
+    } = useTaskStore();
+    const { mutate: deleteTask } = useDeleteTask();
+
+    const handleClickDropdownUpdate = (
+      e?: React.MouseEvent<HTMLButtonElement, MouseEvent>
+    ) => {
+      e?.stopPropagation();
+      setIsTaskUpdateFormShow(true);
+    };
+
+    const handleClickDropdownDelete = (
+      e?: React.MouseEvent<HTMLButtonElement, MouseEvent>
+    ) => {
+      e?.stopPropagation();
+      e?.preventDefault();
+      setIsTaskDeleteDialogOpen(true);
+    };
+
+    const handleClickDeleteConfirm = (taskId: number) => {
+      deleteTask({
+        groupId: selectedTaskList?.groupId ?? -1,
+        taskListId: selectedTaskList?.id ?? -1,
+        taskId,
+        date: selectedDate.toLocaleDateString('ko-KR'),
+      });
+      setIsTaskDeleteDialogOpen(false);
+      setIsTaskUpdateFormShow(false);
+    };
+
     return (
-      <div
-        className={cn(
-          'flex w-full flex-col items-start rounded-lg bg-secondary',
-          'gap-[0.625rem] px-[0.875rem] py-3',
-          'cursor-pointer',
-          'hover:bg-select'
-        )}
-        key={task.id}
-        ref={ref}
-        onClick={onClick}
-      >
-        <div className={cn('flex w-full items-center justify-between')}>
-          <div className="flex w-full items-center justify-start gap-3">
-            <CheckableText
-              isChecked={task.doneAt !== null}
-              onChange={() => {
-                onCheckBoxChange(task.id, !task.doneAt);
-              }}
-            >
-              {task.name}
-            </CheckableText>
-            <div
-              className={cn(
-                'text-sm-regular flex items-center gap-1 text-default'
-              )}
-            >
-              <MessageSquareIcon className="size-4 text-icon-primary" />
-              {task.commentCount}
+      <>
+        <div
+          className={cn(
+            'flex w-full flex-col items-start rounded-lg bg-secondary',
+            'gap-[0.625rem] px-[0.875rem] py-3',
+            'cursor-pointer',
+            'hover:bg-select'
+          )}
+          key={task.id}
+          ref={ref}
+          onClick={onClick}
+        >
+          <div className={cn('flex w-full items-center justify-between')}>
+            <div className="flex w-full items-center justify-start gap-3">
+              <CheckableText
+                isChecked={task.doneAt !== null}
+                onChange={() => {
+                  onCheckBoxChange(task.id, !task.doneAt);
+                }}
+              >
+                {task.name}
+              </CheckableText>
+              <div
+                className={cn(
+                  'text-sm-regular flex items-center gap-1 text-default'
+                )}
+              >
+                <MessageSquareIcon className="size-4 text-icon-primary" />
+                {task.commentCount}
+              </div>
             </div>
+            <Dropdown
+              trigger={
+                <div
+                  className={cn(
+                    'rounded-full p-1',
+                    'hover:bg-tertiary active:bg-select'
+                  )}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                  }}
+                >
+                  <MoreVerticalIcon className="size-4 text-icon-primary" />
+                </div>
+              }
+              dropdownStyle="-translate-x-20 w-28"
+            >
+              <button
+                type="button"
+                className="h-[36px] text-md-regular text-primary"
+                onClick={(e) => handleClickDropdownUpdate(e)}
+              >
+                수정하기
+              </button>
+              <button
+                type="button"
+                className="h-[36px] text-md-regular text-status-danger"
+                onClick={(e) => handleClickDropdownDelete(e)}
+              >
+                삭제하기
+              </button>
+            </Dropdown>
           </div>
           <div
             className={cn(
-              'rounded-full p-2',
-              'hover:bg-tertiary active:bg-select'
+              'ml-2 flex items-center justify-center gap-[0.625rem]'
             )}
-            onClick={(e) => {
-              e.stopPropagation();
-            }}
           >
-            <MoreVerticalIcon className="size-4 text-icon-primary" />
+            <div className="flex items-center gap-1">
+              <CalendarClockIcon className="size-4 text-icon-primary" />
+              <span className="text-xs-regular text-default">
+                {formatKoreanDate(task.date)}
+              </span>
+            </div>
+            {task.frequency !== FrequencyType.Once && (
+              <>
+                <span className="text-xs-regular text-default">|</span>
+                <div className="flex items-center gap-1">
+                  <RepeatIcon className="size-4 text-icon-primary" />
+                  <span className="text-xs-regular text-default">
+                    {formatFrequencyToKorean(task.frequency)}
+                  </span>
+                </div>
+              </>
+            )}
           </div>
         </div>
-        <div
-          className={cn('ml-2 flex items-center justify-center gap-[0.625rem]')}
+        <Dialog
+          open={isTaskDeleteDialogOpen}
+          onOpenChange={setIsTaskDeleteDialogOpen}
         >
-          <div className="flex items-center gap-1">
-            <CalendarClockIcon className="size-4 text-icon-primary" />
-            <span className="text-xs-regular text-default">
-              {formatKoreanDate(task.date)}
-            </span>
-          </div>
-          {task.frequency !== FrequencyType.Once && (
-            <>
-              <span className="text-xs-regular text-default">|</span>
-              <div className="flex items-center gap-1">
-                <RepeatIcon className="size-4 text-icon-primary" />
-                <span className="text-xs-regular text-default">
-                  {formatFrequencyToKorean(task.frequency)}
-                </span>
-              </div>
-            </>
-          )}
-        </div>
-      </div>
+          <DialogContent className="w-80">
+            <DialogHeader>
+              <DialogTitle>할 일을 삭제하시겠습니까?</DialogTitle>
+              <DialogDescription>
+                삭제된 할 일은 복구할 수 없습니다.
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <Button
+                variant="ghost"
+                onClick={() => setIsTaskDeleteDialogOpen(false)}
+              >
+                취소
+              </Button>
+              <Button
+                variant="destructive"
+                onClick={() => handleClickDeleteConfirm(task.id ?? -1)}
+              >
+                삭제
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </>
     );
   }
 );

--- a/src/components/task/TaskCard.tsx
+++ b/src/components/task/TaskCard.tsx
@@ -1,0 +1,93 @@
+import { FrequencyType, Task } from '@/types/tasks.types';
+import {
+  formatFrequencyToKorean,
+  formatKoreanDate,
+} from '@/utils/dateTimeUtils/FormatData';
+import { cn } from '@/utils/tailwind/cn';
+import {
+  CalendarClockIcon,
+  MessageSquareIcon,
+  MoreVerticalIcon,
+  RepeatIcon,
+} from 'lucide-react';
+import { forwardRef } from 'react';
+import CheckableText from '../common/CheckableText';
+
+type TaskCardProps = {
+  task: Task;
+  onCheckBoxChange: (taskId: number, done: boolean) => void;
+  onClick: () => void;
+};
+
+const TaskCard = forwardRef<HTMLDivElement, TaskCardProps>(
+  ({ task, onCheckBoxChange, onClick }, ref) => {
+    return (
+      <div
+        className={cn(
+          'flex w-full flex-col items-start rounded-lg bg-secondary',
+          'gap-[0.625rem] px-[0.875rem] py-3',
+          'cursor-pointer',
+          'hover:bg-select'
+        )}
+        key={task.id}
+        ref={ref}
+        onClick={onClick}
+      >
+        <div className={cn('flex w-full items-center justify-between')}>
+          <div className="flex w-full items-center justify-start gap-3">
+            <CheckableText
+              isChecked={task.doneAt !== null}
+              onChange={() => {
+                onCheckBoxChange(task.id, !task.doneAt);
+              }}
+            >
+              {task.name}
+            </CheckableText>
+            <div
+              className={cn(
+                'text-sm-regular flex items-center gap-1 text-default'
+              )}
+            >
+              <MessageSquareIcon className="size-4 text-icon-primary" />
+              {task.commentCount}
+            </div>
+          </div>
+          <div
+            className={cn(
+              'rounded-full p-2',
+              'hover:bg-tertiary active:bg-select'
+            )}
+            onClick={(e) => {
+              e.stopPropagation();
+            }}
+          >
+            <MoreVerticalIcon className="size-4 text-icon-primary" />
+          </div>
+        </div>
+        <div
+          className={cn('ml-2 flex items-center justify-center gap-[0.625rem]')}
+        >
+          <div className="flex items-center gap-1">
+            <CalendarClockIcon className="size-4 text-icon-primary" />
+            <span className="text-xs-regular text-default">
+              {formatKoreanDate(task.date)}
+            </span>
+          </div>
+          {task.frequency !== FrequencyType.Once && (
+            <>
+              <span className="text-xs-regular text-default">|</span>
+              <div className="flex items-center gap-1">
+                <RepeatIcon className="size-4 text-icon-primary" />
+                <span className="text-xs-regular text-default">
+                  {formatFrequencyToKorean(task.frequency)}
+                </span>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    );
+  }
+);
+
+export default TaskCard;

--- a/src/components/task/Tasks.tsx
+++ b/src/components/task/Tasks.tsx
@@ -12,7 +12,12 @@ import TaskDetailModal from './taskDetail/TaskDetailModal';
 
 function Tasks() {
   const { id } = useRouter().query;
-  const { selectedDate, selectedTaskList } = useTaskStore();
+  const {
+    selectedDate,
+    selectedTaskList,
+    taskDetailModalOpen,
+    setTaskDetailModalOpen,
+  } = useTaskStore();
   const {
     data: team,
     isLoading: isTeamLoading,
@@ -24,9 +29,6 @@ function Tasks() {
     date: new Date(selectedDate).toISOString(),
   });
   const { mutate: updateTaskStatus } = useUpdateTaskStatus();
-
-  const [taskDetailModalOpen, setTaskDetailModalOpen] =
-    useState<boolean>(false);
   const [selectedTask, setSelectedTask] = useState<Task | null>(null);
 
   const handleCheckBoxChange = (taskId: number, done: boolean) => {

--- a/src/components/task/Tasks.tsx
+++ b/src/components/task/Tasks.tsx
@@ -1,23 +1,14 @@
 import { useTeamQuery } from '@/queries/groups.queries';
 import { useTasks, useUpdateTaskStatus } from '@/queries/tasks.queries';
 import { useTaskStore } from '@/store/useTaskStore';
-import { FrequencyType, Task } from '@/types/tasks.types';
-import {
-  formatFrequencyToKorean,
-  formatKoreanDate,
-} from '@/utils/dateTimeUtils/FormatData';
+import { Task } from '@/types/tasks.types';
 import { cn } from '@/utils/tailwind/cn';
-import {
-  CalendarClockIcon,
-  Loader2,
-  MessageSquareIcon,
-  MoreVerticalIcon,
-  RepeatIcon,
-} from 'lucide-react';
+import { Loader2 } from 'lucide-react';
 import { useRouter } from 'next/router';
-import { Button } from '../common/Button/ShadcnButton';
-import CheckableText from '../common/CheckableText';
+import { useState } from 'react';
+import TaskCard from './TaskCard';
 import TaskListSelector from './TaskListSelector';
+import TaskDetailModal from './taskDetail/TaskDetailModal';
 
 function Tasks() {
   const { id } = useRouter().query;
@@ -33,6 +24,19 @@ function Tasks() {
     date: new Date(selectedDate).toISOString(),
   });
   const { mutate: updateTaskStatus } = useUpdateTaskStatus();
+
+  const [taskDetailModalOpen, setTaskDetailModalOpen] =
+    useState<boolean>(false);
+  const [selectedTask, setSelectedTask] = useState<Task | null>(null);
+
+  const handleCheckBoxChange = (taskId: number, done: boolean) => {
+    updateTaskStatus({
+      groupId: Number(id),
+      taskListId: selectedTaskList?.id ?? 0,
+      taskId,
+      done,
+    });
+  };
 
   if (isTeamLoading) {
     return (
@@ -83,75 +87,21 @@ function Tasks() {
         tasks &&
         tasks.length > 0 &&
         tasks.map((task: Task) => (
-          <div
-            className={cn(
-              'flex w-full flex-col items-start rounded-lg bg-secondary',
-              'gap-[0.625rem] px-[0.875rem] py-3'
-            )}
+          <TaskCard
             key={task.id}
-          >
-            <div className="flex w-full items-center justify-between">
-              <div className="flex w-full items-center justify-start gap-3">
-                <CheckableText
-                  isChecked={task.doneAt !== null}
-                  onChange={() => {
-                    updateTaskStatus({
-                      groupId: Number(id),
-                      taskListId: selectedTaskList?.id ?? 0,
-                      taskId: task.id,
-                      done: !task.doneAt,
-                      date: new Date(selectedDate).toLocaleDateString('ko-KR'),
-                    });
-                  }}
-                >
-                  {task.name}
-                </CheckableText>
-                <div
-                  className={cn(
-                    'text-sm-regular flex items-center gap-1 text-default'
-                  )}
-                >
-                  <MessageSquareIcon className="size-4 text-icon-primary" />
-                  {task.commentCount}
-                </div>
-              </div>
-              <Button
-                variant="ghost"
-                size="icon"
-                className={cn(
-                  'rounded-full p-0',
-                  'hover:bg-tertiary active:bg-select'
-                )}
-                onClick={() => {}}
-              >
-                <MoreVerticalIcon className="size-4 text-icon-primary" />
-              </Button>
-            </div>
-            <div
-              className={cn(
-                'ml-2 flex items-center justify-center gap-[0.625rem]'
-              )}
-            >
-              <div className="flex items-center gap-1">
-                <CalendarClockIcon className="size-4 text-icon-primary" />
-                <span className="text-xs-regular text-default">
-                  {formatKoreanDate(task.date)}
-                </span>
-              </div>
-              {task.frequency !== FrequencyType.Once && (
-                <>
-                  <span className="text-xs-regular text-default">|</span>
-                  <div className="flex items-center gap-1">
-                    <RepeatIcon className="size-4 text-icon-primary" />
-                    <span className="text-xs-regular text-default">
-                      {formatFrequencyToKorean(task.frequency)}
-                    </span>
-                  </div>
-                </>
-              )}
-            </div>
-          </div>
+            task={task}
+            onCheckBoxChange={handleCheckBoxChange}
+            onClick={() => {
+              setSelectedTask(task);
+              setTaskDetailModalOpen(true);
+            }}
+          />
         ))}
+      <TaskDetailModal
+        task={selectedTask}
+        open={taskDetailModalOpen}
+        setOpen={setTaskDetailModalOpen}
+      />
       {isTasksFetched && tasks && tasks.length === 0 && (
         <div
           className={cn(

--- a/src/components/task/Tasks.tsx
+++ b/src/components/task/Tasks.tsx
@@ -26,7 +26,7 @@ function Tasks() {
   const { data: tasks, isFetched: isTasksFetched } = useTasks({
     groupId: Number(id),
     taskListId: selectedTaskList?.id ?? 0,
-    date: new Date(selectedDate).toISOString(),
+    date: new Date(selectedDate).toLocaleDateString('ko-KR'),
   });
   const { mutate: updateTaskStatus } = useUpdateTaskStatus();
   const [selectedTask, setSelectedTask] = useState<Task | null>(null);

--- a/src/components/task/taskDetail/TaskCommentForm.tsx
+++ b/src/components/task/taskDetail/TaskCommentForm.tsx
@@ -24,13 +24,13 @@ function TaskCommentForm({ taskId }: { taskId: number }) {
       taskId,
       content: comment.content,
     });
+    reset();
   };
 
   const handleKeyPress = (e: React.KeyboardEvent<HTMLFormElement>) => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       handleSubmit(onSubmit)();
-      reset();
     }
   };
 

--- a/src/components/task/taskDetail/TaskCommentForm.tsx
+++ b/src/components/task/taskDetail/TaskCommentForm.tsx
@@ -1,0 +1,74 @@
+/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
+import Avatar from '@/components/common/Avatar';
+import { Button } from '@/components/common/Button/ShadcnButton';
+import TextArea from '@/components/common/TextArea';
+import { commentSchema } from '@/constants/formSchemas/commentSchema';
+import { useAddComment } from '@/queries/comments.queries';
+import { useAuthStore } from '@/store/useAuthStore';
+import { cn } from '@/utils/tailwind/cn';
+import { ArrowUpIcon } from 'lucide-react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+
+function TaskCommentForm({ taskId }: { taskId: number }) {
+  const { user } = useAuthStore();
+  const { register, handleSubmit, watch, reset } = useForm({
+    defaultValues: {
+      content: '',
+    },
+  });
+  const { mutate: addComment } = useAddComment();
+
+  const onSubmit = (comment: z.infer<typeof commentSchema>) => {
+    addComment({
+      taskId,
+      content: comment.content,
+    });
+  };
+
+  const handleKeyPress = (e: React.KeyboardEvent<HTMLFormElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSubmit(onSubmit)();
+      reset();
+    }
+  };
+
+  return (
+    <div className="flex gap-4">
+      <div className="pt-3">
+        <Avatar src={user?.image || null} />
+      </div>
+      <form
+        className="flex w-full gap-6"
+        onSubmit={handleSubmit(onSubmit)}
+        onKeyPress={handleKeyPress}
+      >
+        <TextArea
+          textAreaClassName={cn(
+            'resize-none',
+            'hover:border-brand-tertiary focus:border-brand-tertiary'
+          )}
+          placeholder="댓글을 입력해주세요."
+          rows={2}
+          {...register('content')}
+        />
+        <div className="pt-3">
+          <Button
+            variant="default"
+            size="icon"
+            disabled={!watch('content')}
+            className={cn(
+              'mt-2 size-8 rounded-full bg-brand-tertiary',
+              'hover:bg-brand-tertiary/80 active:bg-brand-tertiary/60'
+            )}
+          >
+            <ArrowUpIcon className="size-4" />
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+export default TaskCommentForm;

--- a/src/components/task/taskDetail/TaskCommentList.tsx
+++ b/src/components/task/taskDetail/TaskCommentList.tsx
@@ -1,13 +1,22 @@
 import Avatar from '@/components/common/Avatar';
 import { Button } from '@/components/common/Button/ShadcnButton';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/common/Dialog';
 import { Divider } from '@/components/common/Divider';
-import { useGetComments } from '@/queries/comments.queries';
+import Dropdown from '@/components/common/Dropdown';
+import { useDeleteComment, useGetComments } from '@/queries/comments.queries';
 import { useAuthStore } from '@/store/useAuthStore';
 import { Comment } from '@/types/comment.types';
 import formatDistanceToNowKor from '@/utils/dateTimeUtils/FormatDistanceToNow';
 import { cn } from '@/utils/tailwind/cn';
 import { MoreVerticalIcon } from 'lucide-react';
-import { forwardRef } from 'react';
+import { forwardRef, useState } from 'react';
 
 type TaskCommentListProps = {
   taskId: number;
@@ -17,10 +26,28 @@ const TaskCommentList = forwardRef<HTMLDivElement, TaskCommentListProps>(
   ({ taskId, ...props }, ref) => {
     const { data: comments } = useGetComments({ taskId });
     const { user } = useAuthStore();
+    const { mutate: deleteComment } = useDeleteComment();
+
+    const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+    const [selectedCommentId, setSelectedCommentId] = useState<number | null>(
+      null
+    );
 
     const sortedComments = comments?.sort((a, b) => {
       return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
     });
+
+    const handleClickDropdownItem = (option: string, commentId: number) => {
+      if (option === '삭제하기') {
+        setIsDeleteDialogOpen(true);
+        setSelectedCommentId(commentId);
+      }
+    };
+    const handleClickDelete = (commentId: number) => {
+      deleteComment({ commentId, taskId });
+      setIsDeleteDialogOpen(false);
+      setSelectedCommentId(null);
+    };
 
     return (
       <div
@@ -32,7 +59,7 @@ const TaskCommentList = forwardRef<HTMLDivElement, TaskCommentListProps>(
         {...props}
       >
         {sortedComments?.map((comment: Comment) => (
-          <div key={comment.id} className="flex flex-col gap-2">
+          <div key={comment.id} className="flex flex-col gap-3">
             <div
               className={cn(
                 'flex items-center justify-between',
@@ -48,18 +75,47 @@ const TaskCommentList = forwardRef<HTMLDivElement, TaskCommentListProps>(
                 )}
               >
                 {comment.content.toString()}
+                {comment.id}
               </div>
               <div className="flex">
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className={cn(
-                    'h-6 w-6 rounded-full bg-transparent',
-                    'hover:bg-transparent/20 active:bg-transparent/10'
-                  )}
-                >
-                  <MoreVerticalIcon className="h-4 w-4 text-icon-primary" />
-                </Button>
+                {comment.user.id === user?.id && (
+                  <Dropdown
+                    trigger={
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className={cn(
+                          'h-6 w-6 rounded-full bg-transparent',
+                          'hover:bg-transparent/20 active:bg-transparent/10'
+                        )}
+                      >
+                        <MoreVerticalIcon
+                          className={cn('h-4 w-4 text-icon-primary')}
+                        />
+                      </Button>
+                    }
+                    dropdownStyle="-translate-x-20 w-28"
+                  >
+                    <button
+                      type="button"
+                      className="h-[36px] text-md-regular text-primary"
+                      onClick={() =>
+                        handleClickDropdownItem('수정하기', comment.id)
+                      }
+                    >
+                      수정하기
+                    </button>
+                    <button
+                      type="button"
+                      className="h-[36px] text-md-regular text-primary"
+                      onClick={() =>
+                        handleClickDropdownItem('삭제하기', comment.id)
+                      }
+                    >
+                      삭제하기
+                    </button>
+                  </Dropdown>
+                )}
               </div>
             </div>
             <div className="flex items-center justify-between gap-2">
@@ -72,12 +128,7 @@ const TaskCommentList = forwardRef<HTMLDivElement, TaskCommentListProps>(
                   'flex items-center gap-3 text-xs-regular text-primary'
                 )}
               >
-                {comment.updatedAt.length > 0 && (
-                  <>
-                    <span>(수정됨)</span>
-                    {formatDistanceToNowKor(comment.updatedAt)}
-                  </>
-                )}
+                {formatDistanceToNowKor(comment.updatedAt)}
               </div>
             </div>
             <Divider
@@ -86,6 +137,30 @@ const TaskCommentList = forwardRef<HTMLDivElement, TaskCommentListProps>(
             />
           </div>
         ))}
+        <Dialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
+          <DialogContent className="w-80">
+            <DialogHeader>
+              <DialogTitle>댓글을 삭제하시겠습니까?</DialogTitle>
+              <DialogDescription>
+                삭제된 댓글은 복구할 수 없습니다.
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <Button
+                variant="ghost"
+                onClick={() => setIsDeleteDialogOpen(false)}
+              >
+                취소
+              </Button>
+              <Button
+                variant="destructive"
+                onClick={() => handleClickDelete(selectedCommentId ?? -1)}
+              >
+                삭제
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
       </div>
     );
   }

--- a/src/components/task/taskDetail/TaskCommentList.tsx
+++ b/src/components/task/taskDetail/TaskCommentList.tsx
@@ -113,7 +113,7 @@ export default function TaskCommentList({
                     </button>
                     <button
                       type="button"
-                      className="h-[36px] text-md-regular text-primary"
+                      className="h-[36px] text-md-regular text-status-danger"
                       onClick={() => handleClickDropdownDelete(comment.id)}
                     >
                       삭제하기

--- a/src/components/task/taskDetail/TaskCommentList.tsx
+++ b/src/components/task/taskDetail/TaskCommentList.tsx
@@ -1,0 +1,90 @@
+import Avatar from '@/components/common/Avatar';
+import { Button } from '@/components/common/Button/ShadcnButton';
+import { Divider } from '@/components/common/Divider';
+import { useGetComments } from '@/queries/comments.queries';
+import { useAuthStore } from '@/store/useAuthStore';
+import { Comment } from '@/types/comment.types';
+import formatDistanceToNowKor from '@/utils/dateTimeUtils/FormatDistanceToNow';
+import { cn } from '@/utils/tailwind/cn';
+import { MoreVerticalIcon } from 'lucide-react';
+import { forwardRef } from 'react';
+
+type TaskCommentListProps = {
+  taskId: number;
+};
+
+const TaskCommentList = forwardRef<HTMLDivElement, TaskCommentListProps>(
+  ({ taskId, ...props }, ref) => {
+    const { data: comments } = useGetComments({ taskId });
+    const { user } = useAuthStore();
+
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          'flex w-full flex-col gap-4',
+          'w-[43rem] overflow-hidden'
+        )}
+        {...props}
+      >
+        {comments?.map((comment: Comment) => (
+          <div key={comment.id} className="flex flex-col gap-2">
+            <div
+              className={cn(
+                'flex items-center justify-between',
+                comment.user.id === user?.id && 'text-gray-900'
+              )}
+            >
+              <div
+                className={cn(
+                  'mr-12 mt-2 flex',
+                  'max-w-[43rem] flex-nowrap items-center gap-2',
+                  'break-keep text-md-regular text-primary',
+                  'whitespace-normal break-words'
+                )}
+              >
+                {comment.content.toString()}
+              </div>
+              <div className="flex">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className={cn(
+                    'h-6 w-6 rounded-full bg-transparent',
+                    'hover:bg-transparent/20 active:bg-transparent/10'
+                  )}
+                >
+                  <MoreVerticalIcon className="h-4 w-4 text-icon-primary" />
+                </Button>
+              </div>
+            </div>
+            <div className="flex items-center justify-between gap-2">
+              <Avatar
+                src={comment.user.image}
+                userNickname={comment.user.nickname}
+              />
+              <div
+                className={cn(
+                  'flex items-center gap-3 text-xs-regular text-primary'
+                )}
+              >
+                {comment.updatedAt.length > 0 && (
+                  <>
+                    <span>(수정됨)</span>
+                    {formatDistanceToNowKor(comment.updatedAt)}
+                  </>
+                )}
+              </div>
+            </div>
+            <Divider
+              key={`${comment.id}-divider`}
+              className="border-icon-primary"
+            />
+          </div>
+        ))}
+      </div>
+    );
+  }
+);
+
+export default TaskCommentList;

--- a/src/components/task/taskDetail/TaskCommentList.tsx
+++ b/src/components/task/taskDetail/TaskCommentList.tsx
@@ -18,6 +18,10 @@ const TaskCommentList = forwardRef<HTMLDivElement, TaskCommentListProps>(
     const { data: comments } = useGetComments({ taskId });
     const { user } = useAuthStore();
 
+    const sortedComments = comments?.sort((a, b) => {
+      return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+    });
+
     return (
       <div
         ref={ref}
@@ -27,7 +31,7 @@ const TaskCommentList = forwardRef<HTMLDivElement, TaskCommentListProps>(
         )}
         {...props}
       >
-        {comments?.map((comment: Comment) => (
+        {sortedComments?.map((comment: Comment) => (
           <div key={comment.id} className="flex flex-col gap-2">
             <div
               className={cn(

--- a/src/components/task/taskDetail/TaskCommentUpdateForm.tsx
+++ b/src/components/task/taskDetail/TaskCommentUpdateForm.tsx
@@ -1,0 +1,121 @@
+/* eslint-disable max-len */
+/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
+import Avatar from '@/components/common/Avatar';
+import { Button } from '@/components/common/Button/ShadcnButton';
+import { Divider } from '@/components/common/Divider';
+import TextArea from '@/components/common/TextArea';
+import { commentSchema } from '@/constants/formSchemas/commentSchema';
+import { useToast } from '@/hooks/useToast';
+import { useUpdateComment } from '@/queries/comments.queries';
+import { useAuthStore } from '@/store/useAuthStore';
+import { useCommentStore } from '@/store/useCommentStore';
+import { UpdateCommentRequest } from '@/types/dto/requests/comment.request.types';
+import { cn } from '@/utils/tailwind/cn';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+
+type TaskCommentUpdateFormProps = {
+  taskId: number;
+  className?: React.HTMLAttributes<HTMLDivElement>['className'];
+};
+
+function TaskCommentUpdateForm({
+  taskId,
+  className,
+}: TaskCommentUpdateFormProps) {
+  const { user } = useAuthStore();
+  const { selectedComment, setSelectedComment } = useCommentStore();
+  const toast = useToast();
+  const { register, handleSubmit, watch, reset } =
+    useForm<UpdateCommentRequest>({
+      mode: 'onBlur',
+      resolver: zodResolver(commentSchema),
+      defaultValues: {
+        content: selectedComment?.content,
+      },
+    });
+  const { mutate: updateComment } = useUpdateComment();
+
+  const onSubmit = (data: UpdateCommentRequest) => {
+    if (!selectedComment) {
+      toast.toast({
+        title: '댓글을 선택해주세요.',
+      });
+      return;
+    }
+    updateComment({
+      taskId,
+      commentId: selectedComment.id,
+      content: data.content,
+    });
+    setSelectedComment(null);
+  };
+
+  const handleKeyPress = (e: React.KeyboardEvent<HTMLFormElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSubmit(onSubmit);
+      reset();
+    }
+  };
+
+  const handleClickCancel = () => {
+    reset();
+    setSelectedComment(null);
+  };
+
+  return (
+    <div
+      className={cn('flex flex-col gap-3', className)}
+      key={`${selectedComment?.id}-update-form`}
+    >
+      <div className="flex gap-4">
+        <div className="pt-3">
+          <Avatar src={user?.image || null} />
+        </div>
+        <form
+          className="flex w-full flex-col gap-1"
+          onSubmit={handleSubmit(onSubmit)}
+          onKeyPress={handleKeyPress}
+        >
+          <TextArea
+            textAreaClassName={cn(
+              'resize-none',
+              'hover:border-brand-tertiary focus:border-brand-tertiary'
+            )}
+            placeholder="댓글을 입력해주세요."
+            rows={2}
+            defaultValue={selectedComment?.content}
+            {...register('content')}
+          />
+          <div className="mt-2 flex justify-end gap-2">
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={handleClickCancel}
+              className="hover:bg-transparent/20"
+            >
+              취소
+            </Button>
+            <Button
+              type="submit"
+              variant="default"
+              disabled={!watch('content')}
+              className={cn(
+                'rounded-xl border-[1px] border-brand-tertiary p-3',
+                'bg-transparent text-brand-tertiary',
+                'hover:bg-brand-tertiary/15',
+                'hover:border-brand-tertiary/80 active:border-brand-tertiary/60'
+              )}
+            >
+              수정하기
+            </Button>
+          </div>
+        </form>
+      </div>
+      <Divider className="border-icon-primary" />
+    </div>
+  );
+}
+
+export default TaskCommentUpdateForm;

--- a/src/components/task/taskDetail/TaskDetailContent.tsx
+++ b/src/components/task/taskDetail/TaskDetailContent.tsx
@@ -15,6 +15,7 @@ import {
   RepeatIcon,
 } from 'lucide-react';
 import { useState } from 'react';
+import TaskCommentForm from './TaskCommentForm';
 import TaskCommentList from './TaskCommentList';
 
 function TaskDetailContent({ task }: { task: Task }) {
@@ -70,63 +71,6 @@ function TaskDetailContent({ task }: { task: Task }) {
             }
           )}
         >
-          {task.id}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
-          {task.description}
           {task.description}
         </div>
         <Button
@@ -141,6 +85,7 @@ function TaskDetailContent({ task }: { task: Task }) {
           {isExpanded ? '접기' : '펼치기'}
         </Button>
       </article>
+      <TaskCommentForm taskId={task.id} />
       <TaskCommentList taskId={task.id} />
     </section>
   );

--- a/src/components/task/taskDetail/TaskDetailContent.tsx
+++ b/src/components/task/taskDetail/TaskDetailContent.tsx
@@ -68,7 +68,7 @@ function TaskDetailContent({ task }: { task: Task }) {
             }
           )}
         >
-          {task.description}
+          {task.id}
           {task.description}
           {task.description}
           {task.description}

--- a/src/components/task/taskDetail/TaskDetailContent.tsx
+++ b/src/components/task/taskDetail/TaskDetailContent.tsx
@@ -1,0 +1,146 @@
+import Avatar from '@/components/common/Avatar';
+import { Button } from '@/components/common/Button/ShadcnButton';
+import IconAndText from '@/components/common/IconAndText';
+import { Task } from '@/types/tasks.types';
+import {
+  formatFrequencyToKorean,
+  formatKoreanDate,
+} from '@/utils/dateTimeUtils/FormatData';
+import { cn } from '@/utils/tailwind/cn';
+import {
+  CalendarIcon,
+  ChevronDownIcon,
+  ChevronUpIcon,
+  MoreVerticalIcon,
+  RepeatIcon,
+} from 'lucide-react';
+import { useState } from 'react';
+
+function TaskDetailContent({ task }: { task: Task }) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const handleExpand = () => {
+    setIsExpanded(!isExpanded);
+  };
+
+  return (
+    <section className={cn('flex h-full w-full max-w-[45rem] flex-col p-4')}>
+      <article className="flex w-full flex-col gap-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-xl-bold">{task.name}</h2>
+          <Button
+            variant="ghost"
+            className={cn(
+              'size-8 rounded-full p-0',
+              'hover:bg-background-primary/80 active:bg-background-primary/60'
+            )}
+          >
+            <MoreVerticalIcon className="size-4 text-icon-primary" />
+          </Button>
+        </div>
+        <div className="flex items-center justify-between gap-2">
+          <Avatar src={task.writer.image} userNickname={task.writer.nickname} />
+          <p className="text-md-regular text-primary">
+            {formatKoreanDate(task.updatedAt)}
+          </p>
+        </div>
+        <div className="flex items-center justify-start gap-2">
+          <IconAndText
+            wrapperClassName="text-icon-primary"
+            textClassName="text-xs-regular"
+            icon={<CalendarIcon className="size-4" />}
+            text={formatKoreanDate(task.date)}
+          />
+          <span className="text-icon-primary">|</span>
+          <IconAndText
+            wrapperClassName="text-icon-primary"
+            textClassName="text-xs-regular"
+            icon={<RepeatIcon className="size-4" />}
+            text={formatFrequencyToKorean(task.frequency)}
+          />
+        </div>
+        <div
+          className={cn(
+            'overflow-y-scroll break-keep',
+            'text-md-regular text-primary',
+            {
+              'max-h-[20rem]': !isExpanded,
+            }
+          )}
+        >
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+          {task.description}
+        </div>
+        <Button
+          variant="outline"
+          className={cn(
+            'h-8 w-full bg-icon-primary/20 text-xs-regular',
+            'hover:bg-icon-primary/80 active:bg-icon-primary/60'
+          )}
+          onClick={handleExpand}
+        >
+          {isExpanded ? <ChevronUpIcon /> : <ChevronDownIcon />}
+          {isExpanded ? '접기' : '펼치기'}
+        </Button>
+      </article>
+    </section>
+  );
+}
+
+export default TaskDetailContent;

--- a/src/components/task/taskDetail/TaskDetailContent.tsx
+++ b/src/components/task/taskDetail/TaskDetailContent.tsx
@@ -15,6 +15,7 @@ import {
   RepeatIcon,
 } from 'lucide-react';
 import { useState } from 'react';
+import TaskCommentList from './TaskCommentList';
 
 function TaskDetailContent({ task }: { task: Task }) {
   const [isExpanded, setIsExpanded] = useState(false);
@@ -62,6 +63,7 @@ function TaskDetailContent({ task }: { task: Task }) {
         <div
           className={cn(
             'overflow-y-scroll break-keep',
+            'scrollbar-hide hover:scrollbar-default',
             'text-md-regular text-primary',
             {
               'max-h-[20rem]': !isExpanded,
@@ -139,6 +141,7 @@ function TaskDetailContent({ task }: { task: Task }) {
           {isExpanded ? '접기' : '펼치기'}
         </Button>
       </article>
+      <TaskCommentList taskId={task.id} />
     </section>
   );
 }

--- a/src/components/task/taskDetail/TaskDetailContent.tsx
+++ b/src/components/task/taskDetail/TaskDetailContent.tsx
@@ -32,12 +32,14 @@ import TaskUpdateForm from './TaskUpdateForm';
 
 function TaskDetailContent({ task }: { task: Task }) {
   const [isExpanded, setIsExpanded] = useState(false);
-  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const {
     selectedTaskList,
     selectedDate,
     isTaskUpdateFormShow,
     setIsTaskUpdateFormShow,
+    isTaskDeleteDialogOpen,
+    setIsTaskDeleteDialogOpen,
+    setTaskDetailModalOpen,
   } = useTaskStore();
   const { data: taskDetail } = useTaskDetail({
     groupId: selectedTaskList?.groupId ?? -1,
@@ -55,7 +57,7 @@ function TaskDetailContent({ task }: { task: Task }) {
   };
 
   const handleClickDropdownDelete = () => {
-    setIsDeleteDialogOpen(true);
+    setIsTaskDeleteDialogOpen(true);
   };
 
   const handleClickDeleteConfirm = (taskId: number) => {
@@ -65,8 +67,9 @@ function TaskDetailContent({ task }: { task: Task }) {
       taskId,
       date: selectedDate.toLocaleDateString('ko-KR'),
     });
-    setIsDeleteDialogOpen(false);
+    setIsTaskDeleteDialogOpen(false);
     setIsTaskUpdateFormShow(false);
+    setTaskDetailModalOpen(false);
   };
 
   return (
@@ -167,18 +170,21 @@ function TaskDetailContent({ task }: { task: Task }) {
       />
       <TaskCommentForm taskId={taskDetail?.id ?? -1} />
       <TaskCommentList taskId={taskDetail?.id ?? -1} />
-      <Dialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
+      <Dialog
+        open={isTaskDeleteDialogOpen}
+        onOpenChange={setIsTaskDeleteDialogOpen}
+      >
         <DialogContent className="w-80">
           <DialogHeader>
-            <DialogTitle>댓글을 삭제하시겠습니까?</DialogTitle>
+            <DialogTitle>할 일을 삭제하시겠습니까?</DialogTitle>
             <DialogDescription>
-              삭제된 댓글은 복구할 수 없습니다.
+              삭제된 할 일은 복구할 수 없습니다.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
             <Button
               variant="ghost"
-              onClick={() => setIsDeleteDialogOpen(false)}
+              onClick={() => setIsTaskDeleteDialogOpen(false)}
             >
               취소
             </Button>

--- a/src/components/task/taskDetail/TaskDetailContent.tsx
+++ b/src/components/task/taskDetail/TaskDetailContent.tsx
@@ -26,7 +26,9 @@ function TaskDetailContent({ task }: { task: Task }) {
   };
 
   return (
-    <section className={cn('flex h-full w-full max-w-[45rem] flex-col p-4')}>
+    <section
+      className={cn('flex h-full w-full max-w-[45rem] flex-col gap-7 p-4')}
+    >
       <article className="flex w-full flex-col gap-4">
         <div className="flex items-center justify-between">
           <h2 className="text-xl-bold">{task.name}</h2>

--- a/src/components/task/taskDetail/TaskDetailContent.tsx
+++ b/src/components/task/taskDetail/TaskDetailContent.tsx
@@ -10,7 +10,11 @@ import {
 } from '@/components/common/Dialog';
 import Dropdown from '@/components/common/Dropdown';
 import IconAndText from '@/components/common/IconAndText';
-import { useDeleteTask, useTaskDetail } from '@/queries/tasks.queries';
+import {
+  useDeleteTask,
+  useTaskDetail,
+  useUpdateTaskStatus,
+} from '@/queries/tasks.queries';
 import { useTaskStore } from '@/store/useTaskStore';
 import { FrequencyType, Task } from '@/types/tasks.types';
 import {
@@ -47,6 +51,7 @@ function TaskDetailContent({ task }: { task: Task }) {
     taskId: task.id,
   });
   const { mutate: deleteTask } = useDeleteTask();
+  const { mutate: updateTaskStatus } = useUpdateTaskStatus();
 
   const handleExpand = () => {
     setIsExpanded(!isExpanded);
@@ -123,22 +128,49 @@ function TaskDetailContent({ task }: { task: Task }) {
             {formatKoreanDate(taskDetail?.updatedAt ?? '')}
           </p>
         </div>
-        <div className="flex items-center justify-start gap-2">
-          <IconAndText
-            wrapperClassName="text-icon-primary"
-            textClassName="text-xs-regular"
-            icon={<CalendarIcon className="size-4" />}
-            text={formatKoreanDate(taskDetail?.date ?? '')}
-          />
-          <span className="text-icon-primary">|</span>
-          <IconAndText
-            wrapperClassName="text-icon-primary"
-            textClassName="text-xs-regular"
-            icon={<RepeatIcon className="size-4" />}
-            text={formatFrequencyToKorean(
-              taskDetail?.frequency ?? FrequencyType.Once
+        <div className="flex items-center justify-between">
+          <div className="flex items-center justify-start gap-2">
+            <IconAndText
+              wrapperClassName="text-icon-primary"
+              textClassName="text-xs-regular"
+              icon={<CalendarIcon className="size-4" />}
+              text={formatKoreanDate(taskDetail?.date ?? '')}
+            />
+            <span className="text-icon-primary">|</span>
+            <IconAndText
+              wrapperClassName="text-icon-primary"
+              textClassName="text-xs-regular"
+              icon={<RepeatIcon className="size-4" />}
+              text={formatFrequencyToKorean(
+                taskDetail?.frequency ?? FrequencyType.Once
+              )}
+            />
+          </div>
+          <Button
+            variant={taskDetail?.doneAt ? 'secondary' : 'outline'}
+            className={cn(
+              'h-8 border-[1px] border-icon-brand bg-transparent',
+              'text-lg-bold',
+              {
+                'bg-icon-inverse text-brand-primary': taskDetail?.doneAt,
+                'hover:bg-icon-inverse/90': taskDetail?.doneAt,
+                'bg-icon-brand': !taskDetail?.doneAt,
+                'hover:bg-interaction-hover active:bg-interaction-pressed':
+                  !taskDetail?.doneAt,
+                'focus:bg-interaction-focus': !taskDetail?.doneAt,
+              }
             )}
-          />
+            onClick={() => {
+              updateTaskStatus({
+                groupId: selectedTaskList?.groupId ?? -1,
+                taskListId: selectedTaskList?.id ?? -1,
+                taskId: task.id,
+                done: !taskDetail?.doneAt,
+              });
+            }}
+          >
+            {taskDetail?.doneAt ? '완료취소' : '완료하기'}
+          </Button>
         </div>
         <div
           className={cn(

--- a/src/components/task/taskDetail/TaskDetailContent.tsx
+++ b/src/components/task/taskDetail/TaskDetailContent.tsx
@@ -10,9 +10,9 @@ import {
 } from '@/components/common/Dialog';
 import Dropdown from '@/components/common/Dropdown';
 import IconAndText from '@/components/common/IconAndText';
-import { useDeleteTask } from '@/queries/tasks.queries';
+import { useDeleteTask, useTaskDetail } from '@/queries/tasks.queries';
 import { useTaskStore } from '@/store/useTaskStore';
-import { Task } from '@/types/tasks.types';
+import { FrequencyType, Task } from '@/types/tasks.types';
 import {
   formatFrequencyToKorean,
   formatKoreanDate,
@@ -39,7 +39,13 @@ function TaskDetailContent({ task }: { task: Task }) {
     isTaskUpdateFormShow,
     setIsTaskUpdateFormShow,
   } = useTaskStore();
+  const { data: taskDetail } = useTaskDetail({
+    groupId: selectedTaskList?.groupId ?? -1,
+    taskListId: selectedTaskList?.id ?? -1,
+    taskId: task.id,
+  });
   const { mutate: deleteTask } = useDeleteTask();
+
   const handleExpand = () => {
     setIsExpanded(!isExpanded);
   };
@@ -57,7 +63,7 @@ function TaskDetailContent({ task }: { task: Task }) {
       groupId: selectedTaskList?.groupId ?? -1,
       taskListId: selectedTaskList?.id ?? -1,
       taskId,
-      date: selectedDate.toISOString(),
+      date: selectedDate.toLocaleDateString('ko-KR'),
     });
     setIsDeleteDialogOpen(false);
     setIsTaskUpdateFormShow(false);
@@ -73,7 +79,7 @@ function TaskDetailContent({ task }: { task: Task }) {
         })}
       >
         <div className="flex items-center justify-between">
-          <h2 className="text-xl-bold">{task.name}</h2>
+          <h2 className="text-xl-bold">{taskDetail?.name}</h2>
           <Dropdown
             trigger={
               <Button
@@ -106,9 +112,12 @@ function TaskDetailContent({ task }: { task: Task }) {
           </Dropdown>
         </div>
         <div className="flex items-center justify-between gap-2">
-          <Avatar src={task.writer.image} userNickname={task.writer.nickname} />
+          <Avatar
+            src={taskDetail?.writer.image ?? null}
+            userNickname={taskDetail?.writer.nickname}
+          />
           <p className="text-md-regular text-primary">
-            {formatKoreanDate(task.updatedAt)}
+            {formatKoreanDate(taskDetail?.updatedAt ?? '')}
           </p>
         </div>
         <div className="flex items-center justify-start gap-2">
@@ -116,14 +125,16 @@ function TaskDetailContent({ task }: { task: Task }) {
             wrapperClassName="text-icon-primary"
             textClassName="text-xs-regular"
             icon={<CalendarIcon className="size-4" />}
-            text={formatKoreanDate(task.date)}
+            text={formatKoreanDate(taskDetail?.date ?? '')}
           />
           <span className="text-icon-primary">|</span>
           <IconAndText
             wrapperClassName="text-icon-primary"
             textClassName="text-xs-regular"
             icon={<RepeatIcon className="size-4" />}
-            text={formatFrequencyToKorean(task.frequency)}
+            text={formatFrequencyToKorean(
+              taskDetail?.frequency ?? FrequencyType.Once
+            )}
           />
         </div>
         <div
@@ -136,7 +147,7 @@ function TaskDetailContent({ task }: { task: Task }) {
             }
           )}
         >
-          {task.description}
+          {taskDetail?.description}
         </div>
         <Button
           variant="outline"
@@ -152,10 +163,10 @@ function TaskDetailContent({ task }: { task: Task }) {
       </article>
       <TaskUpdateForm
         className={cn({ hidden: !isTaskUpdateFormShow })}
-        task={task}
+        task={taskDetail ?? task}
       />
-      <TaskCommentForm taskId={task.id} />
-      <TaskCommentList taskId={task.id} />
+      <TaskCommentForm taskId={taskDetail?.id ?? -1} />
+      <TaskCommentList taskId={taskDetail?.id ?? -1} />
       <Dialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
         <DialogContent className="w-80">
           <DialogHeader>

--- a/src/components/task/taskDetail/TaskDetailContent.tsx
+++ b/src/components/task/taskDetail/TaskDetailContent.tsx
@@ -28,19 +28,24 @@ import {
 import { useState } from 'react';
 import TaskCommentForm from './TaskCommentForm';
 import TaskCommentList from './TaskCommentList';
+import TaskUpdateForm from './TaskUpdateForm';
 
 function TaskDetailContent({ task }: { task: Task }) {
   const [isExpanded, setIsExpanded] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
-  const { selectedTaskList, selectedDate } = useTaskStore();
-  const { setTaskDetailModalOpen } = useTaskStore();
+  const {
+    selectedTaskList,
+    selectedDate,
+    isTaskUpdateFormShow,
+    setIsTaskUpdateFormShow,
+  } = useTaskStore();
   const { mutate: deleteTask } = useDeleteTask();
   const handleExpand = () => {
     setIsExpanded(!isExpanded);
   };
 
   const handleClickDropdownUpdate = () => {
-    // console.log('update');
+    setIsTaskUpdateFormShow(true);
   };
 
   const handleClickDropdownDelete = () => {
@@ -55,17 +60,20 @@ function TaskDetailContent({ task }: { task: Task }) {
       date: selectedDate.toISOString(),
     });
     setIsDeleteDialogOpen(false);
-    setTaskDetailModalOpen(false);
+    setIsTaskUpdateFormShow(false);
   };
 
   return (
     <section
       className={cn('flex h-full w-full max-w-[45rem] flex-col gap-7 p-4')}
     >
-      <article className="flex w-full flex-col gap-4">
+      <article
+        className={cn('flex w-full flex-col gap-4', {
+          hidden: isTaskUpdateFormShow,
+        })}
+      >
         <div className="flex items-center justify-between">
           <h2 className="text-xl-bold">{task.name}</h2>
-
           <Dropdown
             trigger={
               <Button
@@ -142,6 +150,10 @@ function TaskDetailContent({ task }: { task: Task }) {
           {isExpanded ? '접기' : '펼치기'}
         </Button>
       </article>
+      <TaskUpdateForm
+        className={cn({ hidden: !isTaskUpdateFormShow })}
+        task={task}
+      />
       <TaskCommentForm taskId={task.id} />
       <TaskCommentList taskId={task.id} />
       <Dialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>

--- a/src/components/task/taskDetail/TaskDetailModal.tsx
+++ b/src/components/task/taskDetail/TaskDetailModal.tsx
@@ -1,0 +1,23 @@
+import { Task } from '@/types/tasks.types';
+import { DrawerDialog } from '../../common/DrawerDialog';
+import TaskDetailContent from './TaskDetailContent';
+
+type TaskDetailModalProps = {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  trigger?: React.ReactNode;
+  task: Task | null;
+};
+
+export default function TaskDetailModal({
+  open,
+  setOpen,
+  trigger,
+  task,
+}: TaskDetailModalProps) {
+  return (
+    <DrawerDialog open={open} setOpen={setOpen} trigger={trigger}>
+      {task && <TaskDetailContent task={task} />}
+    </DrawerDialog>
+  );
+}

--- a/src/components/task/taskDetail/TaskUpdateForm.tsx
+++ b/src/components/task/taskDetail/TaskUpdateForm.tsx
@@ -1,0 +1,139 @@
+/* eslint-disable max-len */
+/* eslint-disable import/no-extraneous-dependencies */
+import { updateTaskSchema } from '@/constants/formSchemas/taskSchema';
+import { useUpdateTask } from '@/queries/tasks.queries';
+import { useTaskStore } from '@/store/useTaskStore';
+import { UpdateTaskRequest } from '@/types/dto/requests/tasks.request.types';
+import { Task } from '@/types/tasks.types';
+import { cn } from '@/utils/tailwind/cn';
+import { DevTool } from '@hookform/devtools';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useEffect } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import Button, {
+  ButtonBackgroundColor,
+  ButtonBorderColor,
+  ButtonPadding,
+  ButtonStyle,
+  ButtonWidth,
+  TextColor,
+  TextSize,
+} from '../../common/Button/Button';
+import Input from '../../common/Input';
+import TextArea from '../../common/TextArea';
+
+type TaskUpdateFormProps = {
+  className?: React.HTMLAttributes<HTMLDivElement>['className'];
+  task: Task;
+};
+
+function TaskUpdateForm({ className, task }: TaskUpdateFormProps) {
+  const { selectedDate, selectedTaskList, setIsTaskUpdateFormShow } =
+    useTaskStore();
+  const { mutate: updateTask, isSuccess, isPending } = useUpdateTask();
+  const methods = useForm<UpdateTaskRequest>({
+    mode: 'onBlur',
+    resolver: zodResolver(updateTaskSchema),
+    defaultValues: {
+      name: task.name ?? '',
+      description: task.description ?? '',
+      groupId: selectedTaskList?.groupId,
+      taskListId: selectedTaskList?.id,
+      taskId: task.id,
+      date: selectedDate.toISOString(),
+    },
+  });
+
+  const onSubmit = (data: UpdateTaskRequest) => {
+    if (selectedTaskList) {
+      data.groupId = selectedTaskList.groupId;
+      data.taskListId = selectedTaskList.id;
+      data.taskId = task.id;
+    }
+    updateTask(data);
+  };
+
+  useEffect(() => {
+    if (isSuccess) {
+      setIsTaskUpdateFormShow(false);
+    }
+  }, [isSuccess, setIsTaskUpdateFormShow]);
+
+  return (
+    <FormProvider {...methods}>
+      <form
+        className={cn('my-4 flex flex-col gap-7', className)}
+        onSubmit={methods.handleSubmit(onSubmit)}
+        noValidate
+      >
+        <Input
+          id="title-input"
+          type="text"
+          label="할 일 제목"
+          placeholder="할 일 제목을 입력해주세요."
+          {...methods.register('name')}
+          errorMessage={methods.formState.errors.name?.message}
+        />
+        <TextArea
+          id="description-input"
+          label="할 일 설명"
+          placeholder="할 일 설명을 입력해주세요."
+          textAreaClassName="resize-none"
+          rows={8}
+          {...methods.register('description')}
+          errorMessage={methods.formState.errors.description?.message}
+        />
+        <input
+          type="number"
+          className="hidden"
+          {...methods.register('groupId')}
+          value={selectedTaskList?.groupId}
+        />
+        <input
+          type="number"
+          className="hidden"
+          {...methods.register('taskListId')}
+          value={selectedTaskList?.id}
+        />
+        <input
+          type="number"
+          className="hidden"
+          {...methods.register('taskId')}
+          value={task.id}
+        />
+        <div className="flex justify-end gap-4">
+          <Button
+            type="button"
+            className="hover:bg-transparent/10 active:bg-transparent/20"
+            buttonStyle={ButtonStyle.Box}
+            buttonWidth={ButtonWidth.Fit}
+            buttonPadding={ButtonPadding.Large}
+            buttonBackgroundColor={ButtonBackgroundColor.None}
+            textColor={TextColor.White}
+            textSize={TextSize.Large}
+            buttonBorderColor={ButtonBorderColor.None}
+            onClick={() => setIsTaskUpdateFormShow(false)}
+          >
+            취소
+          </Button>
+          <Button
+            type="submit"
+            buttonStyle={ButtonStyle.Box}
+            buttonWidth={ButtonWidth.Fit}
+            buttonPadding={ButtonPadding.Large}
+            buttonBackgroundColor={ButtonBackgroundColor.Green}
+            textColor={TextColor.White}
+            textSize={TextSize.Large}
+            buttonBorderColor={ButtonBorderColor.None}
+            disabled={isPending}
+          >
+            수정 완료
+          </Button>
+        </div>
+      </form>
+      <DevTool placement="top-left" control={methods.control} />
+    </FormProvider>
+  );
+}
+
+export default TaskUpdateForm;

--- a/src/components/task/taskDetail/TaskUpdateForm.tsx
+++ b/src/components/task/taskDetail/TaskUpdateForm.tsx
@@ -37,10 +37,6 @@ function TaskUpdateForm({ className, task }: TaskUpdateFormProps) {
     defaultValues: {
       name: task.name ?? '',
       description: task.description ?? '',
-      groupId: selectedTaskList?.groupId,
-      taskListId: selectedTaskList?.id,
-      taskId: task.id,
-      date: selectedDate.toISOString(),
     },
   });
 
@@ -49,6 +45,7 @@ function TaskUpdateForm({ className, task }: TaskUpdateFormProps) {
       data.groupId = selectedTaskList.groupId;
       data.taskListId = selectedTaskList.id;
       data.taskId = task.id;
+      data.date = selectedDate.toISOString();
     }
     updateTask(data);
   };
@@ -82,24 +79,6 @@ function TaskUpdateForm({ className, task }: TaskUpdateFormProps) {
           rows={8}
           {...methods.register('description')}
           errorMessage={methods.formState.errors.description?.message}
-        />
-        <input
-          type="number"
-          className="hidden"
-          {...methods.register('groupId')}
-          value={selectedTaskList?.groupId}
-        />
-        <input
-          type="number"
-          className="hidden"
-          {...methods.register('taskListId')}
-          value={selectedTaskList?.id}
-        />
-        <input
-          type="number"
-          className="hidden"
-          {...methods.register('taskId')}
-          value={task.id}
         />
         <div className="flex justify-end gap-4">
           <Button

--- a/src/constants/formSchemas/authSchema.ts
+++ b/src/constants/formSchemas/authSchema.ts
@@ -1,0 +1,51 @@
+import { z } from 'zod';
+
+export const emailSchema = z
+  .string()
+  .min(1, '이메일은 필수 입력입니다.')
+  .email('이메일 형식으로 작성해 주세요.');
+
+export const nicknameSchema = z
+  .string()
+  .min(1, '닉네임은 필수 입력입니다.')
+  .max(20, '닉네임은 최대 20자까지 가능합니다.');
+
+export const passwordSchema = z
+  .string()
+  .min(1, '비밀번호는 필수 입력입니다.')
+  .min(8, '비밀번호는 최소 8자 이상이어야 합니다.')
+  .regex(
+    /^[A-Za-z0-9!@#$%^&*]+$/,
+    '비밀번호는 숫자, 영문, 특수문자로만 가능합니다.'
+  );
+
+export const passwordConfirmationSchema = z
+  .string()
+  .min(1, '비밀번호 확인은 필수 입력입니다.')
+  .min(8, '비밀번호는 최소 8자 이상이어야 합니다.');
+
+export const signInSchema = z.object({
+  email: emailSchema,
+  password: passwordSchema,
+});
+
+export const signUpSchema = z
+  .object({
+    nickname: nicknameSchema,
+    email: emailSchema,
+    password: passwordSchema,
+    passwordConfirmation: passwordConfirmationSchema,
+  })
+  .refine((data) => data.password === data.passwordConfirmation, {
+    message: '비밀번호가 일치하지 않습니다.',
+    path: ['passwordConfirmation'],
+  });
+
+export const resetPasswordSchema = z.object({
+  password: passwordSchema,
+  passwordConfirmation: passwordConfirmationSchema,
+});
+
+export const sendResetPasswordSchema = z.object({
+  email: emailSchema,
+});

--- a/src/constants/formSchemas/commentSchema.ts
+++ b/src/constants/formSchemas/commentSchema.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+export const commentSchema = z.object({
+  content: z
+    .string()
+    .min(1, '댓글을 입력해주세요.')
+    .max(200, '최대 200자입니다.'),
+});

--- a/src/constants/formSchemas/taskSchema.ts
+++ b/src/constants/formSchemas/taskSchema.ts
@@ -34,3 +34,8 @@ export const addTaskSchema = z.object({
   startDate: taskTimeSchema,
   weekDays: taskWeekDaysSchema,
 });
+
+export const updateTaskSchema = z.object({
+  name: taskTitleSchema,
+  description: taskDescriptionSchema,
+});

--- a/src/pages/signin/reset-password/index.tsx
+++ b/src/pages/signin/reset-password/index.tsx
@@ -1,0 +1,100 @@
+import Button, {
+  ButtonBackgroundColor,
+  ButtonBorderColor,
+  ButtonPadding,
+  ButtonStyle,
+  ButtonWidth,
+  TextColor,
+  TextSize,
+} from '@/components/common/Button/Button';
+import Input from '@/components/common/Input';
+import { resetPasswordSchema } from '@/constants/formSchemas/authSchema';
+import { useResetPassword } from '@/queries/users.queries';
+import { ResetPasswordRequest } from '@/types/dto/requests/users.request.types';
+import { cn } from '@/utils/tailwind/cn';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useForm } from 'react-hook-form';
+
+function ResetPasswordPage() {
+  const searchParams = useSearchParams();
+  const { isPending, mutate: resetPassword } = useResetPassword();
+  const router = useRouter();
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors: validErrors },
+  } = useForm<ResetPasswordRequest>({
+    mode: 'onBlur',
+    defaultValues: {
+      password: '',
+      passwordConfirmation: '',
+    },
+    resolver: zodResolver(resetPasswordSchema),
+  });
+
+  const onSubmit = (data: ResetPasswordRequest) => {
+    resetPassword(
+      { ...data, token: searchParams.get('token') as string },
+      {
+        onSuccess: () => router.push('/signin'),
+      }
+    );
+  };
+
+  return (
+    <section
+      className={cn(
+        'mt-[8.75rem] flex w-full max-w-[28.75rem] flex-col items-center',
+        'tab:mt-[6.25rem] mob:mt-[1.5rem]'
+      )}
+    >
+      <div
+        className="mb-20 font-pretendard text-4xl
+										tab:text-2xl-medium
+										mob:mb-7 mob:text-2xl-medium"
+      >
+        비밀번호 재설정
+      </div>
+      <form
+        className="flex w-full flex-col gap-7 font-pretendard"
+        onSubmit={handleSubmit(onSubmit)}
+        noValidate
+      >
+        <Input
+          type="password"
+          id="password-input"
+          label="새 비밀번호"
+          placeholder="비밀번호 (영문, 특수문자, 숫자 포함, 최대 12자)를 입력해주세요."
+          hasVisibilityButton
+          {...register('password')}
+          errorMessage={validErrors.password?.message}
+        />
+        <Input
+          type="password"
+          id="password-confirmation-input"
+          label="비밀번호 확인"
+          placeholder="새 비밀번호를 다시 한번 입력해주세요."
+          {...register('passwordConfirmation')}
+          errorMessage={validErrors.passwordConfirmation?.message}
+        />
+        <Button
+          type="submit"
+          buttonStyle={ButtonStyle.Box}
+          textColor={TextColor.White}
+          textSize={TextSize.Large}
+          buttonWidth={ButtonWidth.Full}
+          buttonBackgroundColor={ButtonBackgroundColor.Green}
+          buttonBorderColor={ButtonBorderColor.None}
+          buttonPadding={ButtonPadding.Large}
+          disabled={isPending}
+        >
+          재설정
+        </Button>
+      </form>
+    </section>
+  );
+}
+
+export default ResetPasswordPage;

--- a/src/queries/comments.queries.ts
+++ b/src/queries/comments.queries.ts
@@ -76,6 +76,9 @@ export const useDeleteComment = () => {
       queryClient.invalidateQueries({
         queryKey: commentsQueryKeys.comments(params.taskId),
       });
+      toast({
+        title: '댓글을 삭제했습니다.',
+      });
     },
     onError: (error) => {
       toast({

--- a/src/queries/comments.queries.ts
+++ b/src/queries/comments.queries.ts
@@ -12,10 +12,16 @@ import {
   GetCommentsRequest,
   UpdateCommentRequest,
 } from '@/types/dto/requests/comment.request.types';
+import {
+  AddCommentResponse,
+  DeleteCommentResponse,
+  GetCommentsResponse,
+  UpdateCommentResponse,
+} from '@/types/dto/responses/comment.request.types';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 export const useGetComments = (params: GetCommentsRequest) => {
-  return useQuery({
+  return useQuery<GetCommentsResponse>({
     queryKey: commentsQueryKeys.comments(params.taskId),
     queryFn: () => getComments(params),
   });
@@ -24,7 +30,7 @@ export const useGetComments = (params: GetCommentsRequest) => {
 export const useAddComment = () => {
   const queryClient = useQueryClient();
   const { toast } = useToast();
-  return useMutation({
+  return useMutation<AddCommentResponse, Error, AddCommentRequest>({
     mutationFn: (params: AddCommentRequest) => addComment(params),
     onSuccess: (_, params) => {
       queryClient.invalidateQueries({
@@ -44,7 +50,7 @@ export const useAddComment = () => {
 export const useUpdateComment = () => {
   const queryClient = useQueryClient();
   const { toast } = useToast();
-  return useMutation({
+  return useMutation<UpdateCommentResponse, Error, UpdateCommentRequest>({
     mutationFn: (params: UpdateCommentRequest) => updateComment(params),
     onSuccess: (_, params) => {
       queryClient.invalidateQueries({
@@ -64,7 +70,7 @@ export const useUpdateComment = () => {
 export const useDeleteComment = () => {
   const queryClient = useQueryClient();
   const { toast } = useToast();
-  return useMutation({
+  return useMutation<DeleteCommentResponse, Error, DeleteCommentRequest>({
     mutationFn: (params: DeleteCommentRequest) => deleteComment(params),
     onSuccess: (_, params) => {
       queryClient.invalidateQueries({

--- a/src/queries/comments.queries.ts
+++ b/src/queries/comments.queries.ts
@@ -56,6 +56,9 @@ export const useUpdateComment = () => {
       queryClient.invalidateQueries({
         queryKey: commentsQueryKeys.comments(params.taskId),
       });
+      toast({
+        title: '댓글을 수정했습니다.',
+      });
     },
     onError: (error) => {
       toast({

--- a/src/queries/comments.queries.ts
+++ b/src/queries/comments.queries.ts
@@ -1,0 +1,82 @@
+import {
+  addComment,
+  deleteComment,
+  getComments,
+  updateComment,
+} from '@/apis/comments.api';
+import { useToast } from '@/hooks/useToast';
+import { commentsQueryKeys } from '@/queries/keys/comments.keys';
+import {
+  AddCommentRequest,
+  DeleteCommentRequest,
+  GetCommentsRequest,
+  UpdateCommentRequest,
+} from '@/types/dto/requests/comment.request.types';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+export const useGetComments = (params: GetCommentsRequest) => {
+  return useQuery({
+    queryKey: commentsQueryKeys.comments(params.taskId),
+    queryFn: () => getComments(params),
+  });
+};
+
+export const useAddComment = () => {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+  return useMutation({
+    mutationFn: (params: AddCommentRequest) => addComment(params),
+    onSuccess: (_, params) => {
+      queryClient.invalidateQueries({
+        queryKey: commentsQueryKeys.comments(params.taskId),
+      });
+    },
+    onError: (error) => {
+      toast({
+        title: '댓글 추가를 실패했습니다.',
+        description: error.message,
+        variant: 'destructive',
+      });
+    },
+  });
+};
+
+export const useUpdateComment = () => {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+  return useMutation({
+    mutationFn: (params: UpdateCommentRequest) => updateComment(params),
+    onSuccess: (_, params) => {
+      queryClient.invalidateQueries({
+        queryKey: commentsQueryKeys.comments(params.taskId),
+      });
+    },
+    onError: (error) => {
+      toast({
+        title: '댓글 수정을 실패했습니다.',
+        description: error.message,
+        variant: 'destructive',
+      });
+    },
+  });
+};
+
+export const useDeleteComment = () => {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+  return useMutation({
+    mutationFn: (params: DeleteCommentRequest) => deleteComment(params),
+    onSuccess: (_, params) => {
+      queryClient.invalidateQueries({
+        queryKey: commentsQueryKeys.comments(params.taskId),
+      });
+    },
+    onError: (error) => {
+      toast({
+        title: '댓글 삭제를 실패했습니다.',
+        description: error.message,
+        variant: 'destructive',
+      });
+    },
+  });
+};

--- a/src/queries/keys/comments.keys.ts
+++ b/src/queries/keys/comments.keys.ts
@@ -1,0 +1,3 @@
+export const commentsQueryKeys = {
+  comments: (taskId: number) => ['comments', taskId],
+};

--- a/src/queries/keys/tasks.keys.ts
+++ b/src/queries/keys/tasks.keys.ts
@@ -1,4 +1,7 @@
-import { GetTaskRequest } from '@/types/dto/requests/tasks.request.types';
+import {
+  GetTaskDetailRequest,
+  GetTaskRequest,
+} from '@/types/dto/requests/tasks.request.types';
 import { formatDate } from '@/utils/dateTimeUtils/FormatData';
 
 export const tasksQueryKeys = {
@@ -7,5 +10,8 @@ export const tasksQueryKeys = {
       params.date = formatDate(params.date);
     }
     return ['tasks', params];
+  },
+  taskDetail: (params: GetTaskDetailRequest) => {
+    return ['taskDetail', params];
   },
 };

--- a/src/queries/tasks.queries.ts
+++ b/src/queries/tasks.queries.ts
@@ -123,6 +123,13 @@ export const useUpdateTaskStatus = () => {
           date: formatDate(params.startDate ?? ''),
         }),
       });
+      queryClient.invalidateQueries({
+        queryKey: tasksQueryKeys.taskDetail({
+          groupId: params.groupId,
+          taskListId: params.taskListId,
+          taskId: params.taskId,
+        }),
+      });
     },
     onError: (error) => {
       toast({

--- a/src/queries/tasks.queries.ts
+++ b/src/queries/tasks.queries.ts
@@ -1,7 +1,13 @@
-import { addTask, getTask, updateTaskStatus } from '@/apis/tasks.api';
+import {
+  addTask,
+  deleteTask,
+  getTask,
+  updateTaskStatus,
+} from '@/apis/tasks.api';
 import { useToast } from '@/hooks/useToast';
 import {
   AddTaskRequest,
+  DeleteTaskRequest,
   GetTaskRequest,
   UpdateTaskStatusRequest,
 } from '@/types/dto/requests/tasks.request.types';
@@ -40,7 +46,6 @@ export const useAddTask = () => {
       toast({
         title: '할 일을 추가했습니다.',
       });
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       queryClient.invalidateQueries({
         queryKey: tasksQueryKeys.tasks({
           groupId: params.groupId,
@@ -61,17 +66,51 @@ export const useAddTask = () => {
 
 export const useUpdateTaskStatus = () => {
   const queryClient = useQueryClient();
+  const { toast } = useToast();
   return useMutation({
     mutationFn: async (params: UpdateTaskStatusRequest) =>
       updateTaskStatus(params),
     onSuccess: (_, params) => {
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       queryClient.invalidateQueries({
         queryKey: tasksQueryKeys.tasks({
           groupId: params.groupId,
           taskListId: params.taskListId,
           date: formatDate(params.date ?? ''),
         }),
+      });
+    },
+    onError: (error) => {
+      toast({
+        title: '할 일 상태 수정을 실패했습니다.',
+        description: error.message,
+        variant: 'destructive',
+      });
+    },
+  });
+};
+
+export const useDeleteTask = () => {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+  return useMutation({
+    mutationFn: async (params: DeleteTaskRequest) => deleteTask(params),
+    onSuccess: (_, params) => {
+      toast({
+        title: '할 일을 삭제했습니다.',
+      });
+      queryClient.invalidateQueries({
+        queryKey: tasksQueryKeys.tasks({
+          groupId: params.groupId,
+          taskListId: params.taskListId,
+          date: formatDate(params.date ?? ''),
+        }),
+      });
+    },
+    onError: (error) => {
+      toast({
+        title: '할 일 삭제를 실패했습니다.',
+        description: error.message,
+        variant: 'destructive',
       });
     },
   });

--- a/src/queries/tasks.queries.ts
+++ b/src/queries/tasks.queries.ts
@@ -2,6 +2,7 @@ import {
   addTask,
   deleteTask,
   getTask,
+  getTaskDetail,
   updateTask,
   updateTaskStatus,
 } from '@/apis/tasks.api';
@@ -9,6 +10,7 @@ import { useToast } from '@/hooks/useToast';
 import {
   AddTaskRequest,
   DeleteTaskRequest,
+  GetTaskDetailRequest,
   GetTaskRequest,
   UpdateTaskRequest,
   UpdateTaskStatusRequest,
@@ -23,6 +25,13 @@ export const useTasks = (params: GetTaskRequest) => {
     queryKey: tasksQueryKeys.tasks(params),
     queryFn: () => getTask(params),
     enabled: !!params.date && !!params.groupId && !!params.taskListId,
+  });
+};
+
+export const useTaskDetail = (params: GetTaskDetailRequest) => {
+  return useQuery({
+    queryKey: tasksQueryKeys.taskDetail(params),
+    queryFn: () => getTaskDetail(params),
   });
 };
 
@@ -80,6 +89,13 @@ export const useUpdateTask = () => {
           groupId: params.groupId,
           taskListId: params.taskListId,
           date: formatDate(params.date ?? ''),
+        }),
+      });
+      queryClient.invalidateQueries({
+        queryKey: tasksQueryKeys.taskDetail({
+          groupId: params.groupId,
+          taskListId: params.taskListId,
+          taskId: params.taskId,
         }),
       });
     },

--- a/src/queries/tasks.queries.ts
+++ b/src/queries/tasks.queries.ts
@@ -2,6 +2,7 @@ import {
   addTask,
   deleteTask,
   getTask,
+  updateTask,
   updateTaskStatus,
 } from '@/apis/tasks.api';
 import { useToast } from '@/hooks/useToast';
@@ -9,6 +10,7 @@ import {
   AddTaskRequest,
   DeleteTaskRequest,
   GetTaskRequest,
+  UpdateTaskRequest,
   UpdateTaskStatusRequest,
 } from '@/types/dto/requests/tasks.request.types';
 import { FrequencyType } from '@/types/tasks.types';
@@ -64,6 +66,33 @@ export const useAddTask = () => {
   });
 };
 
+export const useUpdateTask = () => {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+  return useMutation({
+    mutationFn: async (params: UpdateTaskRequest) => updateTask(params),
+    onSuccess: (_, params) => {
+      toast({
+        title: '할 일을 수정했습니다.',
+      });
+      queryClient.invalidateQueries({
+        queryKey: tasksQueryKeys.tasks({
+          groupId: params.groupId,
+          taskListId: params.taskListId,
+          date: formatDate(params.date ?? ''),
+        }),
+      });
+    },
+    onError: (error) => {
+      toast({
+        title: '할 일 수정을 실패했습니다.',
+        description: error.message,
+        variant: 'destructive',
+      });
+    },
+  });
+};
+
 export const useUpdateTaskStatus = () => {
   const queryClient = useQueryClient();
   const { toast } = useToast();
@@ -75,7 +104,7 @@ export const useUpdateTaskStatus = () => {
         queryKey: tasksQueryKeys.tasks({
           groupId: params.groupId,
           taskListId: params.taskListId,
-          date: formatDate(params.date ?? ''),
+          date: formatDate(params.startDate ?? ''),
         }),
       });
     },

--- a/src/queries/users.queries.ts
+++ b/src/queries/users.queries.ts
@@ -1,15 +1,25 @@
-import { getMemberships, getUser } from '@/apis/users.api';
+import {
+  getMemberships,
+  getUser,
+  resetPassword,
+  sendResetPasswordEmail,
+} from '@/apis/users.api';
+import { useToast } from '@/hooks/useToast';
 import { useAuthStore } from '@/store/useAuthStore';
+import {
+  ResetPasswordRequest,
+  SendResetPasswordEmailRequest,
+} from '@/types/dto/requests/users.request.types';
 import {
   GetMembershipsResponse,
   GetUserResponse,
 } from '@/types/dto/responses/users.response.types';
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { usersQueryKeys } from './keys/users.keys';
 
 export const useGetUser = () => {
   const { user, setUser } = useAuthStore();
-  const { ...returns } = useQuery<GetUserResponse>({
+  return useQuery<GetUserResponse>({
     queryKey: usersQueryKeys.user(),
     queryFn: getUser,
     refetchInterval: 1000 * 50,
@@ -19,17 +29,53 @@ export const useGetUser = () => {
       return data;
     },
   });
-
-  return { ...returns };
 };
 
 export const useGetMemberships = () => {
   const { user } = useAuthStore();
-  const { ...returns } = useQuery<GetMembershipsResponse>({
+  return useQuery<GetMembershipsResponse>({
     queryKey: usersQueryKeys.memberships(),
     queryFn: getMemberships,
     enabled: !!user,
   });
+};
 
-  return { ...returns };
+export const useSendResetPasswordEmail = () => {
+  const { toast } = useToast();
+  return useMutation({
+    mutationFn: async (params: SendResetPasswordEmailRequest) =>
+      sendResetPasswordEmail(params),
+    onSuccess: (response) => {
+      toast({
+        title: response.message,
+      });
+    },
+    onError: (error) => {
+      toast({
+        title: '비밀번호 재설정 메일 전송을 실패했습니다.',
+        description: error.message,
+        variant: 'destructive',
+      });
+    },
+  });
+};
+
+export const useResetPassword = () => {
+  const { toast } = useToast();
+  return useMutation({
+    mutationFn: async (params: ResetPasswordRequest) => resetPassword(params),
+    onSuccess: (response) => {
+      toast({
+        title: '비밀번호 재설정이 완료되었습니다.',
+        description: response.message,
+      });
+    },
+    onError: (error) => {
+      toast({
+        title: '비밀번호 재설정을 실패했습니다.',
+        description: error.message,
+        variant: 'destructive',
+      });
+    },
+  });
 };

--- a/src/store/useCommentStore.ts
+++ b/src/store/useCommentStore.ts
@@ -1,0 +1,28 @@
+import { Comment } from '@/types/comment.types';
+import { create } from 'zustand';
+import { combine } from 'zustand/middleware';
+import { immer } from 'zustand/middleware/immer';
+
+export type CommentState = {
+  selectedComment: Comment | null;
+};
+
+export type CommentActions = {
+  setSelectedComment: (comment: Comment | null) => void;
+};
+
+const initialState: CommentState = {
+  selectedComment: null,
+};
+
+export const useCommentStore = create(
+  immer(
+    combine(initialState, (set) => ({
+      setSelectedComment: (comment: Comment | null) => {
+        set((state) => {
+          state.selectedComment = comment;
+        });
+      },
+    }))
+  )
+);

--- a/src/store/useTaskStore.ts
+++ b/src/store/useTaskStore.ts
@@ -6,16 +6,19 @@ import { immer } from 'zustand/middleware/immer';
 export type TaskState = {
   selectedDate: Date;
   selectedTaskList: TaskList | null;
+  taskDetailModalOpen: boolean;
 };
 
 export type TaskActions = {
   setSelectedDate: (date: Date) => void;
   setSelectedTaskList: (taskList: TaskList) => void;
+  setTaskDetailModalOpen: (open: boolean) => void;
 };
 
 const initialState: TaskState = {
   selectedDate: new Date(),
   selectedTaskList: null,
+  taskDetailModalOpen: false,
 };
 
 export const useTaskStore = create(
@@ -29,6 +32,11 @@ export const useTaskStore = create(
       setSelectedTaskList: (taskList: TaskList) => {
         set((state) => {
           state.selectedTaskList = taskList;
+        });
+      },
+      setTaskDetailModalOpen: (open: boolean) => {
+        set((state) => {
+          state.taskDetailModalOpen = open;
         });
       },
     }))

--- a/src/store/useTaskStore.ts
+++ b/src/store/useTaskStore.ts
@@ -8,6 +8,7 @@ export type TaskState = {
   selectedTaskList: TaskList | null;
   taskDetailModalOpen: boolean;
   isTaskUpdateFormShow: boolean;
+  isTaskDeleteDialogOpen: boolean;
 };
 
 export type TaskActions = {
@@ -15,6 +16,7 @@ export type TaskActions = {
   setSelectedTaskList: (taskList: TaskList) => void;
   setTaskDetailModalOpen: (open: boolean) => void;
   setIsTaskUpdateFormShow: (show: boolean) => void;
+  setIsTaskDeleteDialogOpen: (open: boolean) => void;
 };
 
 const initialState: TaskState = {
@@ -22,6 +24,7 @@ const initialState: TaskState = {
   selectedTaskList: null,
   taskDetailModalOpen: false,
   isTaskUpdateFormShow: false,
+  isTaskDeleteDialogOpen: false,
 };
 
 export const useTaskStore = create(
@@ -45,6 +48,11 @@ export const useTaskStore = create(
       setIsTaskUpdateFormShow: (show: boolean) => {
         set((state) => {
           state.isTaskUpdateFormShow = show;
+        });
+      },
+      setIsTaskDeleteDialogOpen: (open: boolean) => {
+        set((state) => {
+          state.isTaskDeleteDialogOpen = open;
         });
       },
     }))

--- a/src/store/useTaskStore.ts
+++ b/src/store/useTaskStore.ts
@@ -7,18 +7,21 @@ export type TaskState = {
   selectedDate: Date;
   selectedTaskList: TaskList | null;
   taskDetailModalOpen: boolean;
+  isTaskUpdateFormShow: boolean;
 };
 
 export type TaskActions = {
   setSelectedDate: (date: Date) => void;
   setSelectedTaskList: (taskList: TaskList) => void;
   setTaskDetailModalOpen: (open: boolean) => void;
+  setIsTaskUpdateFormShow: (show: boolean) => void;
 };
 
 const initialState: TaskState = {
   selectedDate: new Date(),
   selectedTaskList: null,
   taskDetailModalOpen: false,
+  isTaskUpdateFormShow: false,
 };
 
 export const useTaskStore = create(
@@ -37,6 +40,11 @@ export const useTaskStore = create(
       setTaskDetailModalOpen: (open: boolean) => {
         set((state) => {
           state.taskDetailModalOpen = open;
+        });
+      },
+      setIsTaskUpdateFormShow: (show: boolean) => {
+        set((state) => {
+          state.isTaskUpdateFormShow = show;
         });
       },
     }))

--- a/src/types/comment.types.ts
+++ b/src/types/comment.types.ts
@@ -1,7 +1,7 @@
 import { User } from './users.types';
 
 export type Comment = {
-  writer: Pick<User, 'image' | 'nickname' | 'id'>;
+  user: Pick<User, 'image' | 'nickname' | 'id'>;
   updatedAt: string; // string($date-time)
   createdAt: string; // string($date-time)
   content: string; // 최대 길이: 200

--- a/src/types/comment.types.ts
+++ b/src/types/comment.types.ts
@@ -1,0 +1,9 @@
+import { User } from './users.types';
+
+export type Comment = {
+  writer: Pick<User, 'image' | 'nickname' | 'id'>;
+  updatedAt: string; // string($date-time)
+  createdAt: string; // string($date-time)
+  content: string; // 최대 길이: 200
+  id: number; // IdIdinteger($int32), minimum: 1
+};

--- a/src/types/dto/requests/comment.request.types.ts
+++ b/src/types/dto/requests/comment.request.types.ts
@@ -7,6 +7,7 @@ export type AddCommentRequest = {
 
 export type UpdateCommentRequest = {
   taskId: number;
+  commentId: number;
   content: Comment['content'];
 };
 

--- a/src/types/dto/requests/comment.request.types.ts
+++ b/src/types/dto/requests/comment.request.types.ts
@@ -1,0 +1,20 @@
+import { Comment } from '@/types/comment.types';
+
+export type AddCommentRequest = {
+  taskId: number;
+  content: Comment['content'];
+};
+
+export type UpdateCommentRequest = {
+  taskId: number;
+  content: Comment['content'];
+};
+
+export type DeleteCommentRequest = {
+  taskId: number;
+  commentId: number;
+};
+
+export type GetCommentsRequest = {
+  taskId: number;
+};

--- a/src/types/dto/requests/tasks.request.types.ts
+++ b/src/types/dto/requests/tasks.request.types.ts
@@ -24,3 +24,10 @@ export type AddTaskRequest = {
   weekDays?: number[];
   monthDay?: number;
 };
+
+export type DeleteTaskRequest = {
+  groupId: number;
+  taskListId: number;
+  taskId: number;
+  date?: string;
+};

--- a/src/types/dto/requests/tasks.request.types.ts
+++ b/src/types/dto/requests/tasks.request.types.ts
@@ -6,6 +6,12 @@ export type GetTaskRequest = {
   date?: string; // 날짜는 선택적이며, ISO 8601 형식의 문자열
 };
 
+export type GetTaskDetailRequest = {
+  groupId: number;
+  taskListId: number;
+  taskId: number;
+};
+
 export type UpdateTaskStatusRequest = {
   groupId: number;
   taskListId: number;

--- a/src/types/dto/requests/tasks.request.types.ts
+++ b/src/types/dto/requests/tasks.request.types.ts
@@ -11,6 +11,16 @@ export type UpdateTaskStatusRequest = {
   taskListId: number;
   taskId: number;
   done: boolean;
+  startDate?: string;
+};
+
+export type UpdateTaskRequest = {
+  groupId: number;
+  taskListId: number;
+  taskId: number;
+  name?: string;
+  description?: string;
+  done?: boolean;
   date?: string;
 };
 

--- a/src/types/dto/requests/users.request.types.ts
+++ b/src/types/dto/requests/users.request.types.ts
@@ -1,0 +1,11 @@
+import { User } from '@/types/users.types';
+
+export type SendResetPasswordEmailRequest = Pick<User, 'email'> & {
+  redirectUrl: string;
+};
+
+export type ResetPasswordRequest = {
+  password: string;
+  passwordConfirmation: string;
+  token: string;
+};

--- a/src/types/dto/responses/comment.request.types.ts
+++ b/src/types/dto/responses/comment.request.types.ts
@@ -1,3 +1,5 @@
+import { Comment } from '@/types/comment.types';
+
 export type AddCommentResponse = Comment;
 
 export type GetCommentsResponse = Comment[];

--- a/src/types/dto/responses/comment.request.types.ts
+++ b/src/types/dto/responses/comment.request.types.ts
@@ -1,0 +1,7 @@
+export type AddCommentResponse = Comment;
+
+export type GetCommentsResponse = Comment[];
+
+export type UpdateCommentResponse = Comment;
+
+export type DeleteCommentResponse = Comment;

--- a/src/types/dto/responses/tasks.response.types.ts
+++ b/src/types/dto/responses/tasks.response.types.ts
@@ -2,6 +2,8 @@ import { FrequencyType, Task } from '@/types/tasks.types';
 
 export type GetTaskResponse = Task[];
 
+export type GetTaskDetailResponse = Task;
+
 export type UpdateTaskStatusResponse = Task;
 
 export type UpdateTaskResponse = Task;

--- a/src/types/dto/responses/tasks.response.types.ts
+++ b/src/types/dto/responses/tasks.response.types.ts
@@ -4,6 +4,8 @@ export type GetTaskResponse = Task[];
 
 export type UpdateTaskStatusResponse = Task;
 
+export type UpdateTaskResponse = Task;
+
 export type AddTaskResponse = {
   id: number;
   name: string;

--- a/src/types/dto/responses/users.response.types.ts
+++ b/src/types/dto/responses/users.response.types.ts
@@ -3,3 +3,11 @@ import { Membership, User } from '@/types/users.types';
 export type GetUserResponse = User & { memberships: Membership[] };
 
 export type GetMembershipsResponse = Membership[];
+
+export type SendResetPasswordEmailResponse = {
+  message: string;
+};
+
+export type ResetPasswordResponse = {
+  message: string;
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,3 +1,4 @@
+/* eslint-disable global-require */
 import type { Config } from 'tailwindcss';
 
 const config: Config = {
@@ -188,6 +189,6 @@ const config: Config = {
       },
     },
   },
-  plugins: [],
+  plugins: [require('tailwind-scrollbar-hide')],
 };
 export default config;


### PR DESCRIPTION
### 작업 내용

#### 요구 사항
- **목록 상세 페이지**
  - [x] 상단 스크롤 메뉴로 목록 전환 가능
    - [x] 스크롤 기능 ( 가로 스크롤 )
    - [x] 슬라이드 기능
    - [x] 목록 전환 기능
  - [x] 달력 UI를 이용해 날짜 선택 가능하게 하기
  - [x] 날짜에 해당하는 할 일 리스트
    - [x] 완료 시 체크 가능
    - [x] 할 일 클릭 시 상세 정보 보여주기 - 할 일 상세 페이지 작업 예정
  - [x] 할 일 추가 - 할 일 추가 작업 예정
    - [x] 제목, 상세 내용
    - [ ] 이미지
  - [x] 할 일 목록 편집 - 할 일 추가 작업 예정
    - [ ] 드래그 앤 드롭으로 순서 편집
    - [x] 할 일 삭제

#### 구현 내용

1. UI 컴포넌트 추가
  - Dialog, Drawer, DrawerDialog 컴포넌트를 추가했습니다.
  - Avatar 컴포넌트를 추가하여 사용자 프로필 이미지를 표시할 수 있도록 했습니다.
2. 기능 추가
  - 댓글 관련 API 및 쿼리를 추가하여 댓글 작성, 수정, 삭제 기능을 구현했습니다.
  - 할 일(Task) 관련 API 및 쿼리를 추가하여 할 일의 상세 정보 조회, 수정, 삭제 기능을 구현했습니다.
  - 비밀번호 재설정 기능을 추가하여 사용자가 비밀번호를 재설정할 수 있도록 했습니다.
3. 기타
  - SignInForm, SignUpForm에서 스키마를 분리해 재사용성을 높였습니다.
  - TaskCard, TaskDetailContent 등에서 UI 및 기능을 개선했습니다.

### 스크린샷(선택)
![image](https://github.com/user-attachments/assets/89fd582d-0369-4bb9-bcf5-f0b7e909b8dd)
![image](https://github.com/user-attachments/assets/566a0fb4-e983-45f4-ab29-67e5772c0caf)
![image](https://github.com/user-attachments/assets/f48f16c0-0512-42cf-aa69-9fdd7ca9b21d)
![image](https://github.com/user-attachments/assets/ff29d694-02a0-48c4-8b1e-30788823b862)
![image](https://github.com/user-attachments/assets/e3d972e0-e04f-47e4-bf10-9476fe0c3e02)

### 관련 이슈

- resolves #20 #44 

