### PR TITLE
Feature/102 추가 기능 및 개선 팀 페이지 오류 개선 및 추가 기능

### DIFF
--- a/src/apis/groups.api.ts
+++ b/src/apis/groups.api.ts
@@ -107,15 +107,27 @@ export const postTaskList = async (groupId: number, name: string) => {
 
 export async function getTasks(id: number, date: string) {
   try {
-    const response = await axiosInstance.get<Task[]>(`groups/${id}/tasks`, {
-      params: { date },
+    const response = await axiosInstance<Task[]>({
+      method: 'GET',
+      url: `groups/${id}/tasks`,
+      data: { date },
       headers: {
         'Content-Type': 'application/json',
       },
     });
-    const body = response.data;
-    return body;
+    return response.data;
   } catch (error) {
     throw new Error('할 일을 불러오는 데 실패했습니다.');
+  }
+}
+
+export async function deleteMember(groupId: number, memberUserId: number) {
+  try {
+    await axiosInstance({
+      method: 'DELETE',
+      url: `groups/${groupId}/member/${memberUserId}`,
+    });
+  } catch (error) {
+    throw new Error('멤버 삭제에 실패했습니다.');
   }
 }

--- a/src/apis/taskList.api.ts
+++ b/src/apis/taskList.api.ts
@@ -1,0 +1,33 @@
+import { TaskList } from '@/types/tasklist.types';
+import { axiosInstance } from './_axiosInstance';
+
+export const postTaskList = async (groupId: number, name: string) => {
+  try {
+    const response = await axiosInstance<TaskList>({
+      method: 'POST',
+      url: `/groups/${groupId}/task-lists`,
+      data: { name },
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+    return response.data;
+  } catch (error) {
+    throw new Error('할 일 목록를 생성하는 데 실패했습니다.');
+  }
+};
+
+export const deleteTaskList = async (groupId: number, taskListId: number) => {
+  try {
+    const response = await axiosInstance({
+      method: 'DELETE',
+      url: `/groups/${groupId}/task-lists/${taskListId}`,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+    return response;
+  } catch (error) {
+    throw new Error('');
+  }
+};

--- a/src/components/TaskList/TaskLists.tsx
+++ b/src/components/TaskList/TaskLists.tsx
@@ -93,16 +93,6 @@ export default function TaskLists({ taskLists, id }: TaskListProps) {
     );
   };
 
-  if (taskLists.length === 0) {
-    return (
-      <div className="flex h-[9rem] items-center justify-center">
-        <span className="text-center text-lg-medium text-default">
-          아직 할 일 목록이 없습니다.
-        </span>
-      </div>
-    );
-  }
-
   return (
     <div className="flex flex-col gap-5">
       <div className="flex justify-between">
@@ -147,25 +137,32 @@ export default function TaskLists({ taskLists, id }: TaskListProps) {
           </Modal.Portal>
         </Modal>
       </div>
-
-      <div className="h-[200px]">
-        <VirtualScroll
-          itemHeight={40} // 각 TaskItem의 높이 (패딩과 마진을 고려하여 설정)
-          renderAhead={1} // 미리 렌더링할 항목 수
-        >
-          {taskLists.map((taskList, index) => (
-            <Link key={taskList.id} href={`/${id}/tasks`}>
-              <TaskItem
-                key={taskList.id}
-                taskList={taskList}
-                taskListColor={
-                  TASK_LIST_COLORS[index % TASK_LIST_COLORS.length]
-                }
-              />
-            </Link>
-          ))}
-        </VirtualScroll>
-      </div>
+      {taskLists.length === 0 ? (
+        <div className="flex h-[9rem] items-center justify-center">
+          <span className="text-center text-lg-medium text-default">
+            아직 할 일 목록이 없습니다.
+          </span>
+        </div>
+      ) : (
+        <div className="h-[200px]">
+          <VirtualScroll
+            itemHeight={40} // 각 TaskItem의 높이 (패딩과 마진을 고려하여 설정)
+            renderAhead={1} // 미리 렌더링할 항목 수
+          >
+            {taskLists.map((taskList, index) => (
+              <Link key={taskList.id} href={`/${id}/tasks`}>
+                <TaskItem
+                  key={taskList.id}
+                  taskList={taskList}
+                  taskListColor={
+                    TASK_LIST_COLORS[index % TASK_LIST_COLORS.length]
+                  }
+                />
+              </Link>
+            ))}
+          </VirtualScroll>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/TaskList/TaskLists.tsx
+++ b/src/components/TaskList/TaskLists.tsx
@@ -10,11 +10,15 @@ import Button, {
 } from '@/components/common/Button/Button';
 import { Modal } from '@/components/modal';
 import { useToast } from '@/hooks/useToast';
-import { useTaskListMutation } from '@/queries/groups.queries';
+import {
+  useDeleteTaskList,
+  useTaskListMutation,
+} from '@/queries/taskList.queries';
 import { TaskList } from '@/types/tasklist.types';
 import Image from 'next/image';
-import Link from 'next/link';
+import { useRouter } from 'next/router';
 import { useState } from 'react';
+import Dropdown from '../common/Dropdown';
 import Input from '../common/Input';
 import VirtualScroll from './VirtualScroll';
 
@@ -29,10 +33,23 @@ interface TaskItemProps {
 }
 
 function TaskItem({ taskList, taskListColor }: TaskItemProps) {
+  const router = useRouter();
+  const deleteTask = useDeleteTaskList();
+
+  const handleTaskClick = (e: React.MouseEvent) => {
+    router.push(`/${taskList.groupId}/tasks`);
+    e.stopPropagation();
+  };
+
+  const handleTaskDelete = () => {
+    deleteTask.mutate({ groupId: taskList.groupId, taskListId: taskList.id });
+  };
+
   return (
     <div
       className="relative mb-[10px] flex h-[40px] items-center 
      justify-between rounded-xl bg-secondary px-5"
+      onClick={handleTaskClick}
     >
       <div
         className={`absolute bottom-0 left-0 top-0 
@@ -44,13 +61,32 @@ function TaskItem({ taskList, taskListColor }: TaskItemProps) {
           count={taskList.tasks.filter((task) => task.doneAt).length}
           left={taskList.tasks.length}
         />
-        <Image
-          src="../icons/Kebab_large.svg"
-          alt="kebab"
-          width={16}
-          height={16}
-          style={{ width: 'auto', height: 'auto' }}
-        />
+        <Dropdown
+          dropdownStyle="transform translate-x-[-80%] z-20"
+          trigger={
+            <button
+              type="button"
+              className="z-100 rounded-lg hover:bg-tertiary"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <Image
+                src="../icons/Kebab_large.svg"
+                alt="kebab"
+                width={16}
+                height={16}
+                style={{ width: 'auto', height: 'auto' }}
+              />
+            </button>
+          }
+        >
+          <button
+            className="h-[35px] w-full "
+            type="button"
+            onClick={handleTaskDelete}
+          >
+            삭제하기
+          </button>
+        </Dropdown>
       </div>
     </div>
   );
@@ -150,15 +186,13 @@ export default function TaskLists({ taskLists, id }: TaskListProps) {
             renderAhead={1} // 미리 렌더링할 항목 수
           >
             {taskLists.map((taskList, index) => (
-              <Link key={taskList.id} href={`/${id}/tasks`}>
-                <TaskItem
-                  key={taskList.id}
-                  taskList={taskList}
-                  taskListColor={
-                    TASK_LIST_COLORS[index % TASK_LIST_COLORS.length]
-                  }
-                />
-              </Link>
+              <TaskItem
+                key={taskList.id}
+                taskList={taskList}
+                taskListColor={
+                  TASK_LIST_COLORS[index % TASK_LIST_COLORS.length]
+                }
+              />
             ))}
           </VirtualScroll>
         </div>

--- a/src/components/TaskList/TaskLists.tsx
+++ b/src/components/TaskList/TaskLists.tsx
@@ -9,7 +9,6 @@ import Button, {
   TextSize,
 } from '@/components/common/Button/Button';
 import { Modal } from '@/components/modal';
-import { useToast } from '@/hooks/useToast';
 import {
   useDeleteTaskList,
   useTaskListMutation,
@@ -100,7 +99,6 @@ export default function TaskLists({ taskLists, groupId: id }: TaskListProps) {
     'bg-point-pink',
   ];
   const createTaskList = useTaskListMutation();
-  const { toast } = useToast();
   const [taskListName, setTaskListName] = useState('');
 
   const handleNameChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -109,24 +107,7 @@ export default function TaskLists({ taskLists, groupId: id }: TaskListProps) {
   };
 
   const handleCreateTask = () => {
-    createTaskList.mutate(
-      { groupId: Number(id), name: taskListName },
-      {
-        onSuccess: () => {
-          toast({
-            title: '목록생성 완료',
-            description: '새 목록이 생성되었습니다',
-          });
-        },
-        onError: (err) => {
-          toast({
-            title: '목록생성 실패',
-            description: err.message,
-            variant: 'destructive',
-          });
-        },
-      }
-    );
+    createTaskList.mutate({ groupId: Number(id), name: taskListName });
   };
 
   return (

--- a/src/components/TaskList/TaskLists.tsx
+++ b/src/components/TaskList/TaskLists.tsx
@@ -24,7 +24,7 @@ import VirtualScroll from './VirtualScroll';
 
 interface TaskListProps {
   taskLists: TaskList[];
-  id: string;
+  groupId: string;
 }
 
 interface TaskItemProps {
@@ -62,11 +62,11 @@ function TaskItem({ taskList, taskListColor }: TaskItemProps) {
           left={taskList.tasks.length}
         />
         <Dropdown
-          dropdownStyle="transform translate-x-[-80%] z-20"
+          dropdownStyle="transform translate-x-[-105%] translate-y-[-70%] z-20"
           trigger={
             <button
               type="button"
-              className="z-100 rounded-lg hover:bg-tertiary"
+              className="rounded-lg hover:bg-tertiary"
               onClick={(e) => e.stopPropagation()}
             >
               <Image
@@ -80,7 +80,7 @@ function TaskItem({ taskList, taskListColor }: TaskItemProps) {
           }
         >
           <button
-            className="h-[35px] w-full "
+            className=" h-[35px] w-full "
             type="button"
             onClick={handleTaskDelete}
           >
@@ -92,7 +92,7 @@ function TaskItem({ taskList, taskListColor }: TaskItemProps) {
   );
 }
 
-export default function TaskLists({ taskLists, id }: TaskListProps) {
+export default function TaskLists({ taskLists, groupId: id }: TaskListProps) {
   const TASK_LIST_COLORS = [
     'bg-point-purple',
     'bg-point-blue',

--- a/src/components/Team/MemberDropDown.tsx
+++ b/src/components/Team/MemberDropDown.tsx
@@ -1,0 +1,43 @@
+import { useDeleteMember } from '@/queries/groups.queries';
+import Image from 'next/image';
+import Dropdown from '../common/Dropdown';
+import { MemberProps } from './Members';
+
+export default function MemberDropDown({ member }: MemberProps) {
+  const deleteMember = useDeleteMember();
+
+  const handleDeleteMember = () => {
+    deleteMember.mutate({
+      groupId: member.groupId,
+      memberUserId: member.userId,
+    });
+  };
+
+  return (
+    <Dropdown
+      trigger={
+        <button
+          type="button"
+          onClick={(e) => e.stopPropagation()}
+          className="rounded-lg p-1 hover:bg-tertiary"
+        >
+          <Image
+            src="/icons/Kebab_large.svg"
+            alt="kebab"
+            width={20}
+            height={20}
+          />
+        </button>
+      }
+      dropdownStyle="transform translate-x-[-80%] z-20"
+    >
+      <button
+        type="button"
+        className=" h-[35px] w-full "
+        onClick={handleDeleteMember}
+      >
+        삭제하기
+      </button>
+    </Dropdown>
+  );
+}

--- a/src/components/Team/Members.tsx
+++ b/src/components/Team/Members.tsx
@@ -13,18 +13,20 @@ import { useToast } from '@/hooks/useToast';
 import { Member } from '@/types/dto/responses/group.response.types';
 import Image from 'next/image';
 import { useState } from 'react';
+import MemberDropDown from './MemberDropDown';
 import Pagination from './Pagination';
 
-interface MemberProps {
+export interface MemberProps {
   member: Member;
+  isAdmin?: boolean;
 }
 interface MembersProps {
   members: Member[];
+  isAdmin: boolean;
 }
 
-function MemberItem({ member }: MemberProps) {
+function MemberItem({ member, isAdmin }: MemberProps) {
   const isMobileView = useIsMobile();
-
   const { toast } = useToast();
 
   const handleEmailCopy = () => {
@@ -70,12 +72,7 @@ function MemberItem({ member }: MemberProps) {
                 {member.userEmail}
               </span>
             </div>
-            <Image
-              src="/icons/Kebab_large.svg"
-              alt="kebab"
-              width={16}
-              height={16}
-            />
+            {isAdmin && <MemberDropDown member={member} />}
           </Modal.Toggle>
         ) : (
           <Modal.Toggle
@@ -95,13 +92,7 @@ items-center justify-between rounded-xl bg-secondary px-6 "
                 <span className="text-xs-regular">{member.userEmail}</span>
               </div>
             </div>
-
-            <Image
-              src="/icons/Kebab_large.svg"
-              alt="kebab"
-              width={16}
-              height={16}
-            />
+            {isAdmin && <MemberDropDown member={member} />}
           </Modal.Toggle>
         )}
 
@@ -157,7 +148,7 @@ items-center justify-between rounded-xl bg-secondary px-6 "
   );
 }
 
-export default function Members({ members }: MembersProps) {
+export default function Members({ members, isAdmin }: MembersProps) {
   const LIMIT = 6;
   const [page, setPage] = useState(1);
   const offset = (page - 1) * LIMIT;
@@ -168,7 +159,7 @@ export default function Members({ members }: MembersProps) {
     overflow-y-auto mob:grid-cols-2"
       >
         {members.slice(offset, offset + LIMIT).map((member) => (
-          <MemberItem key={member.userId} member={member} />
+          <MemberItem key={member.userId} member={member} isAdmin={isAdmin} />
         ))}
       </div>
       <Pagination

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -86,7 +86,7 @@ export default function Dropdown({
   }, [closeDropdown, toggleDropdown]);
 
   return (
-    <div className="h-[24px] w-[24px]">
+    <div className="h-[24px] w-[24px]" onClick={(e) => e.stopPropagation()}>
       <div ref={triggerRef}>{trigger}</div>
       {isVisible && (
         <div

--- a/src/components/task/AddTaskListModal.tsx
+++ b/src/components/task/AddTaskListModal.tsx
@@ -1,5 +1,5 @@
 import { useToast } from '@/hooks/useToast';
-import { useTaskListMutation } from '@/queries/groups.queries';
+import { useTaskListMutation } from '@/queries/taskList.queries';
 import { cn } from '@/utils/tailwind/cn';
 import { CalendarPlusIcon } from 'lucide-react';
 import { useRef } from 'react';

--- a/src/hooks/useRedirect.ts
+++ b/src/hooks/useRedirect.ts
@@ -1,0 +1,14 @@
+import { useAuthStore } from '@/store/useAuthStore';
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
+
+export const useRedirect = () => {
+  const { user } = useAuthStore();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!user) {
+      router.push('/signin');
+    }
+  }, [user, router]);
+};

--- a/src/pages/[id]/index.tsx
+++ b/src/pages/[id]/index.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import Button, {
   ButtonBackgroundColor,
   ButtonBorderColor,
@@ -70,8 +69,7 @@ export default function TeamPage() {
             description: '데이터가 클립보드에 복사되었습니다.',
           });
         })
-        .catch((err) => {
-          console.error('클립보드 복사 실패:', err);
+        .catch(() => {
           toast({
             title: '복사 실패',
             description: '데이터 복사를 실패하였습니다.',
@@ -82,27 +80,11 @@ export default function TeamPage() {
   };
 
   const handleEditTeam = () => {
-    router
-      .push(`${group.id}/editteam/`)
-      .catch((error) => console.error('라우팅 오류:', error));
+    router.push(`${group.id}/editteam/`);
   };
 
   const handleDeleteTeam = () => {
-    deleteTeam.mutate(Number(id), {
-      onSuccess: () => {
-        toast({
-          title: '팀 삭제 완료',
-          description: '팀이 삭제되었습니다',
-        });
-        router.push('/').catch((error) => console.error('라우팅 오류:', error));
-      },
-      onError: () => {
-        toast({
-          title: '팀 삭제 실패',
-          variant: 'destructive',
-        });
-      },
-    });
+    deleteTeam.mutate(Number(id));
   };
 
   return (

--- a/src/pages/[id]/index.tsx
+++ b/src/pages/[id]/index.tsx
@@ -20,6 +20,7 @@ import {
   useTeamQuery,
 } from '@/queries/groups.queries';
 import { useGetUser } from '@/queries/users.queries';
+import { Loader } from 'lucide-react';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
@@ -50,7 +51,7 @@ export default function TeamPage() {
   if (!isFetched) {
     return (
       <div className="flex h-[50rem] items-center justify-center">
-        <p className="text-4xl">로딩 중 입니다....</p>
+        <Loader className="size-20 animate-spin text-icon-brand" />
       </div>
     );
   }

--- a/src/pages/[id]/index.tsx
+++ b/src/pages/[id]/index.tsx
@@ -153,8 +153,8 @@ export default function TeamPage() {
           </div>
         </div>
       </div>
-      <TaskLists taskLists={group.taskLists} id={id!.toString()} />
-      {isAdmin && <Report id={Number(id)} />}
+      <TaskLists taskLists={group.taskLists} groupId={id!.toString()} />
+      <Report id={Number(id)} />
 
       <div className="flex justify-between">
         <div className="flex gap-2">

--- a/src/pages/[id]/index.tsx
+++ b/src/pages/[id]/index.tsx
@@ -200,7 +200,7 @@ export default function TeamPage() {
           </Modal.Portal>
         </Modal>
       </div>
-      <Members members={group.members} />
+      <Members members={group.members} isAdmin={isAdmin} />
     </div>
   );
 }

--- a/src/pages/addteam/index.tsx
+++ b/src/pages/addteam/index.tsx
@@ -9,6 +9,7 @@ import Button, {
 } from '@/components/common/Button/Button';
 import Input from '@/components/common/Input';
 import ProfileInput from '@/components/Team/ProfileInput';
+import { useRedirect } from '@/hooks/useRedirect';
 import { useTeamMutation } from '@/queries/groups.queries';
 import { useUploadImageMutation } from '@/queries/uploadImage.query';
 import { PostGroupRequest } from '@/types/dto/requests/group.request.types';
@@ -31,6 +32,7 @@ export default function AddTeam() {
   const router = useRouter();
   const teamMutation = useTeamMutation();
   const uploadImageMutation = useUploadImageMutation();
+  useRedirect();
 
   const {
     register,

--- a/src/pages/attendteam/index.tsx
+++ b/src/pages/attendteam/index.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import Button, {
   ButtonBackgroundColor,
   ButtonBorderColor,
@@ -49,9 +48,7 @@ export default function AttendTeam() {
         description: '로그인 후 이용해주세요.',
         variant: 'destructive',
       });
-      router
-        .replace('/signin')
-        .catch((error) => console.error('라우팅 오류:', error));
+      router.replace('/signin');
     } else {
       teamMutation.mutate(
         {
@@ -66,9 +63,7 @@ export default function AttendTeam() {
             });
           },
           onSuccess: () => {
-            router
-              .replace('/')
-              .catch((error) => console.error('라우팅 오류:', error));
+            router.replace('/');
           },
         }
       );

--- a/src/pages/attendteam/index.tsx
+++ b/src/pages/attendteam/index.tsx
@@ -9,6 +9,7 @@ import Button, {
   TextSize,
 } from '@/components/common/Button/Button';
 import Input from '@/components/common/Input';
+import { useRedirect } from '@/hooks/useRedirect';
 import { useToast } from '@/hooks/useToast';
 import { useInviteGroupMutation } from '@/queries/groups.queries';
 import { useAuthStore } from '@/store/useAuthStore';
@@ -26,9 +27,9 @@ type TeamLinkValues = z.infer<typeof teamSchema>;
 export default function AttendTeam() {
   const router = useRouter();
   const teamMutation = useInviteGroupMutation();
-
   const user = useAuthStore();
   const { toast } = useToast();
+  useRedirect();
 
   const {
     register,

--- a/src/queries/groups.queries.ts
+++ b/src/queries/groups.queries.ts
@@ -15,6 +15,7 @@ import {
   UpdateGroupRequest,
 } from '@/types/dto/requests/group.request.types';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useRouter } from 'next/router';
 import {
   groupsInviteQueryKeys,
   groupsQueryKeys,
@@ -37,8 +38,23 @@ export const usePatchTeamMutation = () => {
 };
 
 export const useDeleteTeamMutation = () => {
+  const router = useRouter();
+  const { toast } = useToast();
   return useMutation({
     mutationFn: (id: number) => deleteGroup(id),
+    onSuccess: () => {
+      toast({
+        title: '해당 팀을 삭제했습니다.',
+      });
+      router.push('/');
+    },
+    onError: (error) => {
+      toast({
+        title: '팀 삭제에 실패했습니다.',
+        description: error.message,
+        variant: 'destructive',
+      });
+    },
   });
 };
 

--- a/src/queries/groups.queries.ts
+++ b/src/queries/groups.queries.ts
@@ -6,14 +6,13 @@ import {
   patchGroup,
   postGroup,
   postInviteGroup,
-  postTaskList,
 } from '@/apis/groups.api';
 import {
   InviteGroupRequest,
   PostGroupRequest,
   UpdateGroupRequest,
 } from '@/types/dto/requests/group.request.types';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import {
   groupsInviteQueryKeys,
   groupsQueryKeys,
@@ -62,25 +61,26 @@ export const useInviteGroupQuery = (id: number) => {
   });
 };
 
-export const useTaskListMutation = () => {
-  const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: (params: { groupId: number; name: string }) =>
-      postTaskList(params.groupId, params.name),
-    onSuccess: (_, params) => {
-      queryClient
-        .invalidateQueries({ queryKey: groupsQueryKeys.groups(params.groupId) })
-        .catch(() => {
-          // eslint-disable-next-line no-console
-          console.error('팀 다시 불러오기 오류');
-        });
-    },
-  });
-};
+// export const useTaskListMutation = () => {
+//   const queryClient = useQueryClient();
+//   return useMutation({
+//     mutationFn: (params: { groupId: number; name: string }) =>
+//       postTaskList(params.groupId, params.name),
+//     onSuccess: (_, params) => {
+//       queryClient
+//         .invalidateQueries(
+//  { queryKey: groupsQueryKeys.groups(params.groupId) })
+//         .catch(() => {
+//           // eslint-disable-next-line no-console
+//           console.error('팀 다시 불러오기 오류');
+//         });
+//     },
+//   });
+// };
 
 export const useTasksQuery = (params: { id: number; date: string }) => {
   return useQuery({
-    queryKey: groupTasksQueryKeys.inviteGroups(params.id),
+    queryKey: groupTasksQueryKeys.Groups(params.id),
     queryFn: () => getTasks(params.id, params.date),
     enabled: !!params.id && !!params.date,
   });

--- a/src/queries/keys/groups.key.ts
+++ b/src/queries/keys/groups.key.ts
@@ -7,5 +7,5 @@ export const groupsInviteQueryKeys = {
 };
 
 export const groupTasksQueryKeys = {
-  inviteGroups: (id: number) => ['groupTask', id],
+  Groups: (id: number) => ['groupTask', id],
 };

--- a/src/queries/taskList.queries.ts
+++ b/src/queries/taskList.queries.ts
@@ -1,35 +1,54 @@
 import { deleteTaskList, postTaskList } from '@/apis/taskList.api';
+import { useToast } from '@/hooks/useToast';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { groupsQueryKeys } from './keys/groups.key';
 
 export const useTaskListMutation = () => {
+  const { toast } = useToast();
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (params: { groupId: number; name: string }) =>
       postTaskList(params.groupId, params.name),
     onSuccess: (_, params) => {
-      queryClient
-        .invalidateQueries({ queryKey: groupsQueryKeys.groups(params.groupId) })
-        .catch(() => {
-          // eslint-disable-next-line no-console
-          console.error('팀 다시 불러오기 오류');
-        });
+      queryClient.invalidateQueries({
+        queryKey: groupsQueryKeys.groups(params.groupId),
+      });
+      toast({
+        title: '목록생성 완료',
+        description: '새 목록이 생성되었습니다',
+      });
+    },
+    onError: (err) => {
+      toast({
+        title: '목록생성 실패',
+        description: err.message,
+        variant: 'destructive',
+      });
     },
   });
 };
 
 export const useDeleteTaskList = () => {
+  const { toast } = useToast();
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (params: { groupId: number; taskListId: number }) =>
       deleteTaskList(params.groupId, params.taskListId),
     onSuccess: (_, params) => {
-      queryClient
-        .invalidateQueries({ queryKey: groupsQueryKeys.groups(params.groupId) })
-        .catch(() => {
-          // eslint-disable-next-line no-console
-          console.error('팀 다시 불러오기 오류');
-        });
+      toast({
+        title: '목록삭제 완료',
+        description: '해당 목록을 삭제하였습니다.',
+      });
+      queryClient.invalidateQueries({
+        queryKey: groupsQueryKeys.groups(params.groupId),
+      });
+    },
+    onError: (err) => {
+      toast({
+        title: '목록삭제 실패',
+        description: err.message,
+        variant: 'destructive',
+      });
     },
   });
 };

--- a/src/queries/taskList.queries.ts
+++ b/src/queries/taskList.queries.ts
@@ -1,0 +1,35 @@
+import { deleteTaskList, postTaskList } from '@/apis/taskList.api';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { groupsQueryKeys } from './keys/groups.key';
+
+export const useTaskListMutation = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (params: { groupId: number; name: string }) =>
+      postTaskList(params.groupId, params.name),
+    onSuccess: (_, params) => {
+      queryClient
+        .invalidateQueries({ queryKey: groupsQueryKeys.groups(params.groupId) })
+        .catch(() => {
+          // eslint-disable-next-line no-console
+          console.error('팀 다시 불러오기 오류');
+        });
+    },
+  });
+};
+
+export const useDeleteTaskList = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (params: { groupId: number; taskListId: number }) =>
+      deleteTaskList(params.groupId, params.taskListId),
+    onSuccess: (_, params) => {
+      queryClient
+        .invalidateQueries({ queryKey: groupsQueryKeys.groups(params.groupId) })
+        .catch(() => {
+          // eslint-disable-next-line no-console
+          console.error('팀 다시 불러오기 오류');
+        });
+    },
+  });
+};


### PR DESCRIPTION
### 작업 내용
- 목록이 없을 때 새로운 목록 추가하기 버튼도 없었던 버그를 수정했습니다.
- 리포트 영역은 어떤 멤버의 어떤 권한이든 보이도록 수정했습니다. (피그마 상으로는 관리자가 아닌 멤버는 보이지 않습니다.)
- 팀 페이지 내부의 할 일목록, 멤버 케밥에 삭제기능을 추가했습니다.
- 데이터를 불러오는 순간 "로딩중입니다…" 대신에 Loader 아이콘 사용하였습니다.
- error 처리를 mutate가 아닌 mutation에 처리하도록 하였습니다.
- 로그인이 되어있지 않을 때 팀 추가 페이지, 참여 페이지에 접근시 로그인 페이지로 리다이렉트 할 수있는 훅을 만들어서 사용했습니다.


### 관련 이슈

- resolves #102 
