### PR TITLE
Fix/추가기능/116 신규 기능 팀 페이지 추가 오류 개선

### DIFF
--- a/src/components/TaskList/TaskLists.tsx
+++ b/src/components/TaskList/TaskLists.tsx
@@ -9,11 +9,11 @@ import Button, {
   TextSize,
 } from '@/components/common/Button/Button';
 import { Modal } from '@/components/modal';
-import { useTaskStore } from '@/store/useTaskStore';
 import {
   useDeleteTaskList,
   useTaskListMutation,
 } from '@/queries/taskList.queries';
+import { useTaskStore } from '@/store/useTaskStore';
 import { TaskList } from '@/types/tasklist.types';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
@@ -25,14 +25,16 @@ import VirtualScroll from './VirtualScroll';
 interface TaskListProps {
   taskLists: TaskList[];
   groupId: string;
+  isMember: boolean;
 }
 
 interface TaskItemProps {
   taskList: TaskList;
   taskListColor: string;
+  isMember: boolean;
 }
 
-function TaskItem({ taskList, taskListColor }: TaskItemProps) {
+function TaskItem({ taskList, taskListColor, isMember }: TaskItemProps) {
   const router = useRouter();
   const deleteTask = useDeleteTaskList();
   const { setSelectedTaskList } = useTaskStore();
@@ -63,38 +65,45 @@ function TaskItem({ taskList, taskListColor }: TaskItemProps) {
           count={taskList.tasks.filter((task) => task.doneAt).length}
           left={taskList.tasks.length}
         />
-        <Dropdown
-          dropdownStyle="transform translate-x-[-105%] translate-y-[-70%] z-20"
-          trigger={
-            <button
-              type="button"
-              className="rounded-lg hover:bg-tertiary"
-              onClick={(e) => e.stopPropagation()}
-            >
-              <Image
-                src="../icons/Kebab_large.svg"
-                alt="kebab"
-                width={16}
-                height={16}
-                style={{ width: 'auto', height: 'auto' }}
-              />
-            </button>
-          }
-        >
-          <button
-            className=" h-[35px] w-full "
-            type="button"
-            onClick={handleTaskDelete}
+        {isMember && (
+          <Dropdown
+            dropdownStyle="transform translate-x-[-105%]
+             translate-y-[-70%] z-20"
+            trigger={
+              <button
+                type="button"
+                className="rounded-lg hover:bg-tertiary"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <Image
+                  src="../icons/Kebab_large.svg"
+                  alt="kebab"
+                  width={16}
+                  height={16}
+                  style={{ width: 'auto', height: 'auto' }}
+                />
+              </button>
+            }
           >
-            삭제하기
-          </button>
-        </Dropdown>
+            <button
+              className=" h-[35px] w-full "
+              type="button"
+              onClick={handleTaskDelete}
+            >
+              삭제하기
+            </button>
+          </Dropdown>
+        )}
       </div>
     </div>
   );
 }
 
-export default function TaskLists({ taskLists, groupId: id }: TaskListProps) {
+export default function TaskLists({
+  taskLists,
+  groupId: id,
+  isMember,
+}: TaskListProps) {
   const TASK_LIST_COLORS = [
     'bg-point-purple',
     'bg-point-blue',
@@ -120,42 +129,43 @@ export default function TaskLists({ taskLists, groupId: id }: TaskListProps) {
           <p className="text-lg-medium">할 일 목록</p>
           <p className="text-lg-medium text-default">({taskLists.length}개)</p>
         </div>
-
-        <Modal>
-          <Modal.Toggle className="text-brand-primary">
-            + 새로운 목록 추가하기
-          </Modal.Toggle>
-          <Modal.Portal>
-            <Modal.Overlay />
-            <Modal.Content withToggle>
-              <div className="flex flex-col gap-5">
-                <Modal.Header>
-                  <Modal.Title>할 일 목록</Modal.Title>
-                </Modal.Header>
-                <Input
-                  id="task-list-name"
-                  wrapperClassName="w-[280px]"
-                  placeholder="목록 명을 입력해주세요"
-                  onChange={handleNameChange}
-                />
-                <Modal.Close>
-                  <Button
-                    buttonStyle={ButtonStyle.Box}
-                    textColor={TextColor.White}
-                    textSize={TextSize.Large}
-                    buttonWidth={ButtonWidth.Full}
-                    buttonBackgroundColor={ButtonBackgroundColor.Green}
-                    buttonBorderColor={ButtonBorderColor.Green}
-                    buttonPadding={ButtonPadding.Medium}
-                    onClick={handleCreateTask}
-                  >
-                    만들기
-                  </Button>
-                </Modal.Close>
-              </div>
-            </Modal.Content>
-          </Modal.Portal>
-        </Modal>
+        {isMember && (
+          <Modal>
+            <Modal.Toggle className="text-brand-primary">
+              + 새로운 목록 추가하기
+            </Modal.Toggle>
+            <Modal.Portal>
+              <Modal.Overlay />
+              <Modal.Content withToggle>
+                <div className="flex flex-col gap-5">
+                  <Modal.Header>
+                    <Modal.Title>할 일 목록</Modal.Title>
+                  </Modal.Header>
+                  <Input
+                    id="task-list-name"
+                    wrapperClassName="w-[280px]"
+                    placeholder="목록 명을 입력해주세요"
+                    onChange={handleNameChange}
+                  />
+                  <Modal.Close>
+                    <Button
+                      buttonStyle={ButtonStyle.Box}
+                      textColor={TextColor.White}
+                      textSize={TextSize.Large}
+                      buttonWidth={ButtonWidth.Full}
+                      buttonBackgroundColor={ButtonBackgroundColor.Green}
+                      buttonBorderColor={ButtonBorderColor.Green}
+                      buttonPadding={ButtonPadding.Medium}
+                      onClick={handleCreateTask}
+                    >
+                      만들기
+                    </Button>
+                  </Modal.Close>
+                </div>
+              </Modal.Content>
+            </Modal.Portal>
+          </Modal>
+        )}
       </div>
       {taskLists.length === 0 ? (
         <div className="flex h-[9rem] items-center justify-center">
@@ -176,6 +186,7 @@ export default function TaskLists({ taskLists, groupId: id }: TaskListProps) {
                 taskListColor={
                   TASK_LIST_COLORS[index % TASK_LIST_COLORS.length]
                 }
+                isMember={isMember}
               />
             ))}
           </VirtualScroll>

--- a/src/components/Team/Members.tsx
+++ b/src/components/Team/Members.tsx
@@ -131,7 +131,6 @@ items-center justify-between rounded-xl bg-secondary px-6 "
                   alt="user"
                   width={52}
                   height={52}
-                  style={{ width: 'auto', height: 'auto' }}
                 />
               </div>
               <div className="flex flex-col items-center gap-2">

--- a/src/components/Team/Members.tsx
+++ b/src/components/Team/Members.tsx
@@ -7,10 +7,17 @@ import Button, {
   TextColor,
   TextSize,
 } from '@/components/common/Button/Button';
-import { Modal } from '@/components/modal';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+} from '@/components/common/Dialog';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { useToast } from '@/hooks/useToast';
 import { Member } from '@/types/dto/responses/group.response.types';
+import { DialogTitle } from '@radix-ui/react-dialog';
 import Image from 'next/image';
 import { useState } from 'react';
 import MemberDropDown from './MemberDropDown';
@@ -28,6 +35,7 @@ interface MembersProps {
 function MemberItem({ member, isAdmin }: MemberProps) {
   const isMobileView = useIsMobile();
   const { toast } = useToast();
+  const [isMemberModal, setIsMemberModal] = useState(false);
 
   const handleEmailCopy = () => {
     navigator.clipboard
@@ -43,18 +51,25 @@ function MemberItem({ member, isAdmin }: MemberProps) {
           variant: 'destructive',
         });
       });
+    setIsMemberModal(false);
   };
 
   return (
     <div>
-      <Modal>
-        {isMobileView ? (
-          <Modal.Toggle
-            className="flex h-[74px] w-full items-center justify-between 
+      {isMobileView ? (
+        <div
+          className="flex h-[74px] w-full items-center justify-between 
     rounded-xl bg-secondary px-6 "
-          >
-            <div className="flex w-full flex-col items-start gap-1">
-              <div className="flex w-full items-center gap-2">
+          onClick={() => {
+            setIsMemberModal(true);
+          }}
+        >
+          <div className="flex w-full flex-col items-start gap-1">
+            <div className="flex w-full items-center gap-2">
+              <div
+                className="flex h-[24px] w-[24px] items-center
+             overflow-hidden rounded-full border-2 border-primary "
+              >
                 <Image
                   src={
                     member.userImage ? member.userImage : '/icons/Member.svg'
@@ -64,22 +79,26 @@ function MemberItem({ member, isAdmin }: MemberProps) {
                   height={24}
                   style={{ width: '24px', height: '24px' }}
                 />
-                <span className="truncate text-md-medium">
-                  {member.userName}
-                </span>
               </div>
-              <span className="truncate text-xs-regular">
-                {member.userEmail}
-              </span>
+              <span className="truncate text-md-medium">{member.userName}</span>
             </div>
-            {isAdmin && <MemberDropDown member={member} />}
-          </Modal.Toggle>
-        ) : (
-          <Modal.Toggle
-            className="flex h-[74px] w-full
+            <span className="truncate text-xs-regular">{member.userEmail}</span>
+          </div>
+          {isAdmin && <MemberDropDown member={member} />}
+        </div>
+      ) : (
+        <div
+          className="flex h-[74px] w-full
 items-center justify-between rounded-xl bg-secondary px-6 "
-          >
-            <div className="flex gap-4 mob:items-center">
+          onClick={() => {
+            setIsMemberModal(true);
+          }}
+        >
+          <div className="flex gap-4 mob:items-center">
+            <div
+              className="flex h-[32px] w-[32px] items-center
+             overflow-hidden rounded-full border-2 border-primary "
+            >
               <Image
                 src={member.userImage ? member.userImage : '/icons/Member.svg'}
                 alt="user"
@@ -87,63 +106,63 @@ items-center justify-between rounded-xl bg-secondary px-6 "
                 height={32}
                 style={{ width: 'auto', height: 'auto' }}
               />
-              <div className="flex flex-col items-start gap-1">
-                <span className="text-md-medium">{member.userName}</span>
-                <span className="text-xs-regular">{member.userEmail}</span>
+            </div>
+            <div className="flex flex-col items-start gap-1">
+              <span className="text-md-medium">{member.userName}</span>
+              <span className="text-xs-regular">{member.userEmail}</span>
+            </div>
+          </div>
+          {isAdmin && <MemberDropDown member={member} />}
+        </div>
+      )}
+
+      <Dialog open={isMemberModal} onOpenChange={setIsMemberModal}>
+        <DialogContent className="w-90 fixed">
+          <DialogHeader className="items-center">
+            <div className="flex w-[20rem] flex-col items-center gap-5">
+              <div
+                className="flex h-[52px] w-[52px] items-center
+             overflow-hidden rounded-full border-2 border-primary "
+              >
+                <Image
+                  src={
+                    member.userImage ? member.userImage : '/icons/Member.svg'
+                  }
+                  alt="user"
+                  width={52}
+                  height={52}
+                  style={{ width: 'auto', height: 'auto' }}
+                />
+              </div>
+              <div className="flex flex-col items-center gap-2">
+                <DialogTitle className="truncate text-lg-medium ">
+                  {member.userName}
+                </DialogTitle>
+                <span className="truncate text-md-regular ">
+                  {member.userEmail}
+                </span>
+                <DialogDescription>
+                  멤버의 이메일을 복사할 수 있습니다.
+                </DialogDescription>
               </div>
             </div>
-            {isAdmin && <MemberDropDown member={member} />}
-          </Modal.Toggle>
-        )}
-
-        <Modal.Portal>
-          <Modal.Overlay />
-          <Modal.Content withToggle>
-            <div className="flex flex-col gap-5">
-              <Modal.Header>
-                <Modal.Title>
-                  <div className="flex w-[20rem] flex-col items-center gap-5">
-                    <Image
-                      src={
-                        member.userImage
-                          ? member.userImage
-                          : '/icons/Member.svg'
-                      }
-                      alt="user"
-                      width={52}
-                      height={52}
-                      style={{ width: 'auto', height: 'auto' }}
-                    />
-                    <div className="flex flex-col items-center gap-2">
-                      <span className="truncate text-lg-medium ">
-                        {member.userName}
-                      </span>
-                      <span className="truncate text-md-regular ">
-                        {member.userEmail}
-                      </span>
-                    </div>
-                  </div>
-                </Modal.Title>
-              </Modal.Header>
-
-              <Modal.Close>
-                <Button
-                  buttonStyle={ButtonStyle.Box}
-                  textColor={TextColor.White}
-                  textSize={TextSize.Large}
-                  buttonWidth={ButtonWidth.Full}
-                  buttonBackgroundColor={ButtonBackgroundColor.Green}
-                  buttonBorderColor={ButtonBorderColor.Green}
-                  buttonPadding={ButtonPadding.Medium}
-                  onClick={handleEmailCopy}
-                >
-                  이메일 복사하기
-                </Button>
-              </Modal.Close>
-            </div>
-          </Modal.Content>
-        </Modal.Portal>
-      </Modal>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              buttonStyle={ButtonStyle.Box}
+              textColor={TextColor.White}
+              textSize={TextSize.Large}
+              buttonWidth={ButtonWidth.Full}
+              buttonBackgroundColor={ButtonBackgroundColor.Green}
+              buttonBorderColor={ButtonBorderColor.Green}
+              buttonPadding={ButtonPadding.Medium}
+              onClick={handleEmailCopy}
+            >
+              이메일 복사하기
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/hooks/useRedirect.ts
+++ b/src/hooks/useRedirect.ts
@@ -1,14 +1,19 @@
-import { useAuthStore } from '@/store/useAuthStore';
+import { useGetUser } from '@/queries/users.queries';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
+import { useToast } from './useToast';
 
 export const useRedirect = () => {
-  const { user } = useAuthStore();
   const router = useRouter();
+  const { data, isLoading } = useGetUser();
+  const { toast } = useToast();
 
   useEffect(() => {
-    if (!user) {
+    if (!isLoading && !data) {
       router.push('/signin');
+      toast({
+        title: '로그인 후 접근이 가능한 페이지입니다.',
+      });
     }
-  }, [user, router]);
+  }, [data, isLoading, router, toast]);
 };

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,0 +1,59 @@
+import Button, {
+  ButtonBackgroundColor,
+  ButtonBorderColor,
+  ButtonPadding,
+  ButtonStyle,
+  ButtonWidth,
+  TextColor,
+  TextSize,
+} from '@/components/common/Button/Button';
+import Image from 'next/image';
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <div className="mt-[14rem] flex flex-col items-center gap-20">
+      <Image
+        src="/images/WithoutTeam.svg"
+        alt="withoutTeam"
+        width={810}
+        height={255}
+        className="h-auto w-full max-w-[700px] 
+          tab:max-w-[520px] mob:max-w-[312px]"
+      />
+      <span className="text-center text-lg-medium text-default">
+        아직 소속된 팀이 없습니다.
+        <br />
+        팀을 생성하거나 팀에 참여해보세요.
+      </span>
+      <div className="flex w-[11.625rem] flex-col gap-4">
+        <Link href="/addteam">
+          <Button
+            buttonStyle={ButtonStyle.Box}
+            textColor={TextColor.White}
+            textSize={TextSize.Large}
+            buttonWidth={ButtonWidth.Full}
+            buttonBackgroundColor={ButtonBackgroundColor.Green}
+            buttonBorderColor={ButtonBorderColor.Green}
+            buttonPadding={ButtonPadding.Medium}
+          >
+            팀 생성하기
+          </Button>
+        </Link>
+        <Link href="attendteam">
+          <Button
+            buttonStyle={ButtonStyle.Box}
+            textColor={TextColor.Green}
+            textSize={TextSize.Large}
+            buttonWidth={ButtonWidth.Full}
+            buttonBackgroundColor={ButtonBackgroundColor.None}
+            buttonBorderColor={ButtonBorderColor.Green}
+            buttonPadding={ButtonPadding.Medium}
+          >
+            팀 참여하기
+          </Button>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/[id]/index.tsx
+++ b/src/pages/[id]/index.tsx
@@ -7,6 +7,14 @@ import Button, {
   TextColor,
   TextSize,
 } from '@/components/common/Button/Button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/common/Dialog';
 import DropDown from '@/components/common/Dropdown';
 import { Modal } from '@/components/modal';
 import TaskLists from '@/components/TaskList/TaskLists';
@@ -19,6 +27,7 @@ import {
   useTeamQuery,
 } from '@/queries/groups.queries';
 import { useGetUser } from '@/queries/users.queries';
+
 import { Loader } from 'lucide-react';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
@@ -32,6 +41,7 @@ export default function TeamPage() {
   const { data: inviteLink } = useInviteGroupQuery(Number(id));
   const { data: user } = useGetUser();
   const [isAdmin, setIsAdmin] = useState(false);
+  const [isDeleteTeamModal, setIsDeleteTeamModal] = useState(false);
 
   useEffect(() => {
     if (user) {
@@ -83,8 +93,12 @@ export default function TeamPage() {
     router.push(`${group.id}/editteam/`);
   };
 
+  const handleDeleteModal = () => {
+    setIsDeleteTeamModal(true);
+  };
   const handleDeleteTeam = () => {
     deleteTeam.mutate(Number(id));
+    setIsDeleteTeamModal(false);
   };
 
   return (
@@ -127,7 +141,7 @@ export default function TeamPage() {
                 <button
                   className="h-[35px] w-full "
                   type="button"
-                  onClick={handleDeleteTeam}
+                  onClick={handleDeleteModal}
                 >
                   삭제하기
                 </button>
@@ -138,7 +152,6 @@ export default function TeamPage() {
       </div>
       <TaskLists taskLists={group.taskLists} groupId={id!.toString()} />
       <Report id={Number(id)} />
-
       <div className="flex justify-between">
         <div className="flex gap-2">
           <p className="text-lg-medium">멤버</p>
@@ -183,6 +196,45 @@ export default function TeamPage() {
         </Modal>
       </div>
       <Members members={group.members} isAdmin={isAdmin} />
+      <Dialog open={isDeleteTeamModal} onOpenChange={setIsDeleteTeamModal}>
+        <DialogContent className="fixed w-80">
+          <DialogHeader className="items-center ">
+            <DialogTitle className="items-center"> {group.name} </DialogTitle>
+            팀을 삭제하시겠어요?
+            <DialogDescription>
+              삭제된 할 팀은 복구할 수 없습니다.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              buttonStyle={ButtonStyle.Box}
+              textColor={TextColor.Gray}
+              textSize={TextSize.Large}
+              buttonWidth={ButtonWidth.Full}
+              buttonBackgroundColor={ButtonBackgroundColor.White}
+              buttonBorderColor={ButtonBorderColor.LightGray}
+              buttonPadding={ButtonPadding.Medium}
+              onClick={() => {
+                setIsDeleteTeamModal(false);
+              }}
+            >
+              닫기
+            </Button>
+            <Button
+              buttonStyle={ButtonStyle.Box}
+              textColor={TextColor.White}
+              textSize={TextSize.Large}
+              buttonWidth={ButtonWidth.Full}
+              buttonBackgroundColor={ButtonBackgroundColor.Red}
+              buttonBorderColor={ButtonBorderColor.None}
+              buttonPadding={ButtonPadding.Medium}
+              onClick={handleDeleteTeam}
+            >
+              팀 삭제
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/pages/[id]/index.tsx
+++ b/src/pages/[id]/index.tsx
@@ -198,8 +198,9 @@ export default function TeamPage() {
       <Members members={group.members} isAdmin={isAdmin} />
       <Dialog open={isDeleteTeamModal} onOpenChange={setIsDeleteTeamModal}>
         <DialogContent className="fixed w-80">
-          <DialogHeader className="items-center ">
-            <DialogTitle className="items-center"> {group.name} </DialogTitle>
+          <DialogHeader className="items-center gap-1 ">
+            <Image src="/icons/Alert.svg" alt="alert" width={25} height={25} />
+            <DialogTitle> {group.name} </DialogTitle>
             팀을 삭제하시겠어요?
             <DialogDescription>
               삭제된 할 팀은 복구할 수 없습니다.
@@ -211,8 +212,8 @@ export default function TeamPage() {
               textColor={TextColor.Gray}
               textSize={TextSize.Large}
               buttonWidth={ButtonWidth.Full}
-              buttonBackgroundColor={ButtonBackgroundColor.White}
-              buttonBorderColor={ButtonBorderColor.LightGray}
+              buttonBackgroundColor={ButtonBackgroundColor.Green}
+              buttonBorderColor={ButtonBorderColor.Green}
               buttonPadding={ButtonPadding.Medium}
               onClick={() => {
                 setIsDeleteTeamModal(false);
@@ -222,7 +223,7 @@ export default function TeamPage() {
             </Button>
             <Button
               buttonStyle={ButtonStyle.Box}
-              textColor={TextColor.White}
+              textColor={TextColor.Gray}
               textSize={TextSize.Large}
               buttonWidth={ButtonWidth.Full}
               buttonBackgroundColor={ButtonBackgroundColor.Red}

--- a/src/pages/[id]/index.tsx
+++ b/src/pages/[id]/index.tsx
@@ -32,7 +32,7 @@ import { Loader } from 'lucide-react';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
-import WithOutTeam from '../withoutteam';
+import NotFound from '../404';
 
 export default function TeamPage() {
   const router = useRouter();
@@ -41,6 +41,7 @@ export default function TeamPage() {
   const { data: inviteLink } = useInviteGroupQuery(Number(id));
   const { data: user } = useGetUser();
   const [isAdmin, setIsAdmin] = useState(false);
+  const [isMember, setIsMember] = useState(false);
   const [isDeleteTeamModal, setIsDeleteTeamModal] = useState(false);
   useRedirect();
 
@@ -49,8 +50,11 @@ export default function TeamPage() {
       const member = user.memberships.find(
         (membership) => membership.groupId === group?.id
       );
-      if (member?.role === 'ADMIN') {
-        setIsAdmin(true);
+      if (member) {
+        setIsMember(true);
+        if (member.role === 'ADMIN') {
+          setIsAdmin(true);
+        }
       }
     }
   }, [user, group]);
@@ -66,7 +70,7 @@ export default function TeamPage() {
     );
   }
   if (isError || !group) {
-    return <WithOutTeam />;
+    return <NotFound />;
   }
 
   const handleInviteGroup = () => {
@@ -151,7 +155,11 @@ export default function TeamPage() {
           </div>
         </div>
       </div>
-      <TaskLists taskLists={group.taskLists} groupId={id!.toString()} />
+      <TaskLists
+        taskLists={group.taskLists}
+        groupId={id!.toString()}
+        isMember={isMember}
+      />
       <Report id={Number(id)} />
       <div className="flex justify-between">
         <div className="flex gap-2">
@@ -160,41 +168,42 @@ export default function TeamPage() {
             ({group.members.length}개)
           </p>
         </div>
-
-        <Modal>
-          <Modal.Toggle className="text-brand-primary">
-            + 새로운 멤버 초대하기
-          </Modal.Toggle>
-          <Modal.Portal>
-            <Modal.Overlay />
-            <Modal.Content withToggle>
-              <div className="flex flex-col gap-5">
-                <div>
-                  <Modal.Header>
-                    <Modal.Title>멤버 초대</Modal.Title>
-                  </Modal.Header>
-                  <Modal.Summary>
-                    그룹에 참여할 수 있는 링크를 복사 합니다.
-                  </Modal.Summary>
+        {isMember && (
+          <Modal>
+            <Modal.Toggle className="text-brand-primary">
+              + 새로운 멤버 초대하기
+            </Modal.Toggle>
+            <Modal.Portal>
+              <Modal.Overlay />
+              <Modal.Content withToggle>
+                <div className="flex flex-col gap-5">
+                  <div>
+                    <Modal.Header>
+                      <Modal.Title>멤버 초대</Modal.Title>
+                    </Modal.Header>
+                    <Modal.Summary>
+                      그룹에 참여할 수 있는 링크를 복사 합니다.
+                    </Modal.Summary>
+                  </div>
+                  <Modal.Close>
+                    <Button
+                      buttonStyle={ButtonStyle.Box}
+                      textColor={TextColor.White}
+                      textSize={TextSize.Large}
+                      buttonWidth={ButtonWidth.Full}
+                      buttonBackgroundColor={ButtonBackgroundColor.Green}
+                      buttonBorderColor={ButtonBorderColor.Green}
+                      buttonPadding={ButtonPadding.Medium}
+                      onClick={handleInviteGroup}
+                    >
+                      링크 복사하기
+                    </Button>
+                  </Modal.Close>
                 </div>
-                <Modal.Close>
-                  <Button
-                    buttonStyle={ButtonStyle.Box}
-                    textColor={TextColor.White}
-                    textSize={TextSize.Large}
-                    buttonWidth={ButtonWidth.Full}
-                    buttonBackgroundColor={ButtonBackgroundColor.Green}
-                    buttonBorderColor={ButtonBorderColor.Green}
-                    buttonPadding={ButtonPadding.Medium}
-                    onClick={handleInviteGroup}
-                  >
-                    링크 복사하기
-                  </Button>
-                </Modal.Close>
-              </div>
-            </Modal.Content>
-          </Modal.Portal>
-        </Modal>
+              </Modal.Content>
+            </Modal.Portal>
+          </Modal>
+        )}
       </div>
       <Members members={group.members} isAdmin={isAdmin} />
       <Dialog open={isDeleteTeamModal} onOpenChange={setIsDeleteTeamModal}>

--- a/src/pages/[id]/index.tsx
+++ b/src/pages/[id]/index.tsx
@@ -20,6 +20,7 @@ import { Modal } from '@/components/modal';
 import TaskLists from '@/components/TaskList/TaskLists';
 import Members from '@/components/Team/Members';
 import Report from '@/components/Team/Report';
+import { useRedirect } from '@/hooks/useRedirect';
 import { useToast } from '@/hooks/useToast';
 import {
   useDeleteTeamMutation,
@@ -27,7 +28,6 @@ import {
   useTeamQuery,
 } from '@/queries/groups.queries';
 import { useGetUser } from '@/queries/users.queries';
-
 import { Loader } from 'lucide-react';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
@@ -42,6 +42,7 @@ export default function TeamPage() {
   const { data: user } = useGetUser();
   const [isAdmin, setIsAdmin] = useState(false);
   const [isDeleteTeamModal, setIsDeleteTeamModal] = useState(false);
+  useRedirect();
 
   useEffect(() => {
     if (user) {

--- a/src/queries/groups.queries.ts
+++ b/src/queries/groups.queries.ts
@@ -21,6 +21,7 @@ import {
   groupsQueryKeys,
   groupTasksQueryKeys,
 } from './keys/groups.key';
+import { usersQueryKeys } from './keys/users.keys';
 
 export const useTeamQuery = (id: number) => {
   return useQuery({
@@ -31,9 +32,26 @@ export const useTeamQuery = (id: number) => {
 };
 
 export const usePatchTeamMutation = () => {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
   return useMutation({
     mutationFn: ({ id, name, image }: UpdateGroupRequest) =>
       patchGroup({ id, name, ...(image && { image }) }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: usersQueryKeys.memberships(),
+      });
+      toast({
+        title: '해당 팀을 수정했습니다.',
+      });
+    },
+    onError: (error) => {
+      toast({
+        title: '팀 수정을 실패했습니다.',
+        description: error.message,
+        variant: 'destructive',
+      });
+    },
   });
 };
 
@@ -59,15 +77,49 @@ export const useDeleteTeamMutation = () => {
 };
 
 export const useTeamMutation = () => {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
   return useMutation({
     mutationFn: (params: PostGroupRequest) => postGroup(params),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: usersQueryKeys.memberships(),
+      });
+      toast({
+        title: '해당 팀을 생성했습니다.',
+      });
+    },
+    onError: (error) => {
+      toast({
+        title: '팀 생성을 실패했습니다.',
+        description: error.message,
+        variant: 'destructive',
+      });
+    },
   });
 };
 
 export const useInviteGroupMutation = () => {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
   return useMutation({
     mutationFn: ({ userEmail, token }: InviteGroupRequest) =>
       postInviteGroup({ userEmail, token }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: usersQueryKeys.memberships(),
+      });
+      toast({
+        title: '팀 참여 완료.',
+      });
+    },
+    onError: (error) => {
+      toast({
+        title: '팀 참여에 실패했습니다.',
+        description: error.message,
+        variant: 'destructive',
+      });
+    },
   });
 };
 

--- a/src/queries/groups.queries.ts
+++ b/src/queries/groups.queries.ts
@@ -56,11 +56,15 @@ export const usePatchTeamMutation = () => {
 };
 
 export const useDeleteTeamMutation = () => {
+  const queryClient = useQueryClient();
   const router = useRouter();
   const { toast } = useToast();
   return useMutation({
     mutationFn: (id: number) => deleteGroup(id),
     onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: usersQueryKeys.memberships(),
+      });
       toast({
         title: '해당 팀을 삭제했습니다.',
       });

--- a/src/queries/taskList.queries.ts
+++ b/src/queries/taskList.queries.ts
@@ -7,8 +7,17 @@ export const useTaskListMutation = () => {
   const { toast } = useToast();
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (params: { groupId: number; name: string }) =>
-      postTaskList(params.groupId, params.name),
+    mutationFn: (params: { groupId: number; name: string }) => {
+      if (!params.name.trim()) {
+        toast({
+          title: '목록생성 실패',
+          description: '할일 목록명을 작성해주세요.',
+          variant: 'destructive',
+        });
+        return Promise.reject(new Error('할일 목록명을 작성해주세요.'));
+      }
+      return postTaskList(params.groupId, params.name);
+    },
     onSuccess: (_, params) => {
       queryClient.invalidateQueries({
         queryKey: groupsQueryKeys.groups(params.groupId),

--- a/src/queries/users.queries.ts
+++ b/src/queries/users.queries.ts
@@ -20,16 +20,13 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 import { usersQueryKeys } from './keys/users.keys';
 
 export const useGetUser = () => {
-
   const { setUser } = useAuthStore();
-
   return useQuery<GetUserResponse>({
     queryKey: usersQueryKeys.user(),
     queryFn: getUser,
     refetchInterval: 1000 * 50,
     select: (data) => {
       setUser(data);
-      setMemberships(data.memberships);
       return data;
     },
     retry: 1,

--- a/src/queries/users.queries.ts
+++ b/src/queries/users.queries.ts
@@ -20,16 +20,16 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 import { usersQueryKeys } from './keys/users.keys';
 
 export const useGetUser = () => {
-  const { user, setUser } = useAuthStore();
+  const { setUser } = useAuthStore();
   return useQuery<GetUserResponse>({
     queryKey: usersQueryKeys.user(),
     queryFn: getUser,
     refetchInterval: 1000 * 50,
-    enabled: !!user,
     select: (data) => {
       setUser(data);
       return data;
     },
+    retry: 1,
   });
 };
 


### PR DESCRIPTION
### 작업 내용

- 프로필 이미지 격자가 정상적이지 않은 오류를 해결했습니다.
- 할일 목록명을 비워놓고 추가시도시 에러처리를 추가했습니다.
- 팀을 추가, 수정, 삭제, 참여시 멤버십쿼리키에 invalidate로직을 추가했습니다.
- Redirect 훅이 더욱 정상적으로 작동할 수 있도록 수정했습니다.
- 팀 삭제시 모달로 추가 질문을 던지도록 로직을 수정했습니다.
- 멤버의 모달의 DOM에러가 생겨서 로직을 수정했습니다.

### 관련 이슈

- resolves #116 
