### PR TITLE
Fix/124 할일목록페이지 할일삭제 모달 위치 수정

### DIFF
--- a/src/components/task/DeleteTaskModal.tsx
+++ b/src/components/task/DeleteTaskModal.tsx
@@ -1,0 +1,65 @@
+import { useDeleteTask } from '@/queries/tasks.queries';
+import { useTaskStore } from '@/store/useTaskStore';
+import { Button } from '../common/Button/ShadcnButton';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../common/Dialog';
+
+function DeleteTaskModal() {
+  const {
+    selectedTaskList,
+    setIsTaskUpdateFormShow,
+    isTaskDeleteDialogOpen,
+    setIsTaskDeleteDialogOpen,
+    selectedDate,
+    selectedTask,
+    setSelectedTask,
+  } = useTaskStore();
+  const { mutate: deleteTask } = useDeleteTask();
+
+  const handleClickDeleteConfirm = () => {
+    deleteTask({
+      groupId: selectedTaskList?.groupId ?? -1,
+      taskListId: selectedTaskList?.id ?? -1,
+      taskId: selectedTask?.id ?? -1,
+      date: selectedDate.toLocaleDateString('ko-KR'),
+    });
+    setSelectedTask(null);
+    setIsTaskDeleteDialogOpen(false);
+    setIsTaskUpdateFormShow(false);
+  };
+
+  return (
+    <Dialog
+      open={isTaskDeleteDialogOpen}
+      onOpenChange={setIsTaskDeleteDialogOpen}
+    >
+      <DialogContent className="w-80">
+        <DialogHeader>
+          <DialogTitle>할 일을 삭제하시겠습니까?</DialogTitle>
+          <DialogDescription>
+            삭제된 할 일은 복구할 수 없습니다.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button
+            variant="ghost"
+            onClick={() => setIsTaskDeleteDialogOpen(false)}
+          >
+            취소
+          </Button>
+          <Button variant="destructive" onClick={handleClickDeleteConfirm}>
+            삭제
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default DeleteTaskModal;

--- a/src/components/task/TaskCard.tsx
+++ b/src/components/task/TaskCard.tsx
@@ -1,4 +1,3 @@
-import { useDeleteTask } from '@/queries/tasks.queries';
 import { useTaskStore } from '@/store/useTaskStore';
 import { FrequencyType, Task } from '@/types/tasks.types';
 import {
@@ -7,21 +6,13 @@ import {
 } from '@/utils/dateTimeUtils/FormatData';
 import { cn } from '@/utils/tailwind/cn';
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogTitle,
-} from '@radix-ui/react-dialog';
-import {
   CalendarClockIcon,
   MessageSquareIcon,
   MoreVerticalIcon,
   RepeatIcon,
 } from 'lucide-react';
 import { forwardRef } from 'react';
-import { Button } from '../common/Button/ShadcnButton';
 import CheckableText from '../common/CheckableText';
-import { DialogFooter, DialogHeader } from '../common/Dialog';
 import Dropdown from '../common/Dropdown';
 
 type TaskCardProps = {
@@ -33,13 +24,10 @@ type TaskCardProps = {
 const TaskCard = forwardRef<HTMLDivElement, TaskCardProps>(
   ({ task, onCheckBoxChange, onClick }, ref) => {
     const {
-      selectedTaskList,
       setIsTaskUpdateFormShow,
-      isTaskDeleteDialogOpen,
       setIsTaskDeleteDialogOpen,
-      selectedDate,
+      setSelectedTask,
     } = useTaskStore();
-    const { mutate: deleteTask } = useDeleteTask();
 
     const handleClickDropdownUpdate = (
       e?: React.MouseEvent<HTMLButtonElement, MouseEvent>
@@ -53,136 +41,95 @@ const TaskCard = forwardRef<HTMLDivElement, TaskCardProps>(
     ) => {
       e?.stopPropagation();
       e?.preventDefault();
+      setSelectedTask(task);
       setIsTaskDeleteDialogOpen(true);
     };
 
-    const handleClickDeleteConfirm = (taskId: number) => {
-      deleteTask({
-        groupId: selectedTaskList?.groupId ?? -1,
-        taskListId: selectedTaskList?.id ?? -1,
-        taskId,
-        date: selectedDate.toLocaleDateString('ko-KR'),
-      });
-      setIsTaskDeleteDialogOpen(false);
-      setIsTaskUpdateFormShow(false);
-    };
-
     return (
-      <>
-        <div
-          className={cn(
-            'flex w-full flex-col items-start rounded-lg bg-secondary',
-            'gap-[0.625rem] px-[0.875rem] py-3',
-            'cursor-pointer',
-            'hover:bg-select'
-          )}
-          key={task.id}
-          ref={ref}
-          onClick={onClick}
-        >
-          <div className={cn('flex w-full items-center justify-between')}>
-            <div className="flex w-full items-center justify-start gap-3">
-              <CheckableText
-                isChecked={task.doneAt !== null}
-                onChange={() => {
-                  onCheckBoxChange(task.id, !task.doneAt);
-                }}
-              >
-                {task.name}
-              </CheckableText>
+      <div
+        className={cn(
+          'flex w-full flex-col items-start rounded-lg bg-secondary',
+          'gap-[0.625rem] px-[0.875rem] py-3',
+          'cursor-pointer',
+          'hover:bg-select'
+        )}
+        key={task.id}
+        ref={ref}
+        onClick={onClick}
+      >
+        <div className={cn('flex w-full items-center justify-between')}>
+          <div className="flex w-full items-center justify-start gap-3">
+            <CheckableText
+              isChecked={task.doneAt !== null}
+              onChange={() => {
+                onCheckBoxChange(task.id, !task.doneAt);
+              }}
+            >
+              {task.name}
+            </CheckableText>
+            <div
+              className={cn(
+                'text-sm-regular flex items-center gap-1 text-default'
+              )}
+            >
+              <MessageSquareIcon className="size-4 text-icon-primary" />
+              {task.commentCount}
+            </div>
+          </div>
+          <Dropdown
+            trigger={
               <div
                 className={cn(
-                  'text-sm-regular flex items-center gap-1 text-default'
+                  'rounded-full p-1',
+                  'hover:bg-tertiary active:bg-select'
                 )}
+                onClick={(e) => {
+                  e.stopPropagation();
+                }}
               >
-                <MessageSquareIcon className="size-4 text-icon-primary" />
-                {task.commentCount}
+                <MoreVerticalIcon className="size-4 text-icon-primary" />
               </div>
-            </div>
-            <Dropdown
-              trigger={
-                <div
-                  className={cn(
-                    'rounded-full p-1',
-                    'hover:bg-tertiary active:bg-select'
-                  )}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                  }}
-                >
-                  <MoreVerticalIcon className="size-4 text-icon-primary" />
-                </div>
-              }
-              dropdownStyle="-translate-x-20 w-28"
-            >
-              <button
-                type="button"
-                className="h-[36px] text-md-regular text-primary"
-                onClick={(e) => handleClickDropdownUpdate(e)}
-              >
-                수정하기
-              </button>
-              <button
-                type="button"
-                className="h-[36px] text-md-regular text-status-danger"
-                onClick={(e) => handleClickDropdownDelete(e)}
-              >
-                삭제하기
-              </button>
-            </Dropdown>
-          </div>
-          <div
-            className={cn(
-              'ml-2 flex items-center justify-center gap-[0.625rem]'
-            )}
+            }
+            dropdownStyle="-translate-x-20 w-28"
           >
-            <div className="flex items-center gap-1">
-              <CalendarClockIcon className="size-4 text-icon-primary" />
-              <span className="text-xs-regular text-default">
-                {formatKoreanDate(task.date)}
-              </span>
-            </div>
-            {task.frequency !== FrequencyType.Once && (
-              <>
-                <span className="text-xs-regular text-default">|</span>
-                <div className="flex items-center gap-1">
-                  <RepeatIcon className="size-4 text-icon-primary" />
-                  <span className="text-xs-regular text-default">
-                    {formatFrequencyToKorean(task.frequency)}
-                  </span>
-                </div>
-              </>
-            )}
-          </div>
+            <button
+              type="button"
+              className="h-[36px] text-md-regular text-primary"
+              onClick={(e) => handleClickDropdownUpdate(e)}
+            >
+              수정하기
+            </button>
+            <button
+              type="button"
+              className="h-[36px] text-md-regular text-status-danger"
+              onClick={(e) => handleClickDropdownDelete(e)}
+            >
+              삭제하기
+            </button>
+          </Dropdown>
         </div>
-        <Dialog
-          open={isTaskDeleteDialogOpen}
-          onOpenChange={setIsTaskDeleteDialogOpen}
+        <div
+          className={cn('ml-2 flex items-center justify-center gap-[0.625rem]')}
         >
-          <DialogContent className="w-80">
-            <DialogHeader>
-              <DialogTitle>할 일을 삭제하시겠습니까?</DialogTitle>
-              <DialogDescription>
-                삭제된 할 일은 복구할 수 없습니다.
-              </DialogDescription>
-            </DialogHeader>
-            <DialogFooter>
-              <Button
-                variant="ghost"
-                onClick={() => setIsTaskDeleteDialogOpen(false)}
-              >
-                취소
-              </Button>
-              <Button
-                variant="destructive"
-                onClick={() => handleClickDeleteConfirm(task.id ?? -1)}
-              >
-                삭제
-              </Button>
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
-      </>
+          <div className="flex items-center gap-1">
+            <CalendarClockIcon className="size-4 text-icon-primary" />
+            <span className="text-xs-regular text-default">
+              {formatKoreanDate(task.date)}
+            </span>
+          </div>
+          {task.frequency !== FrequencyType.Once && (
+            <>
+              <span className="text-xs-regular text-default">|</span>
+              <div className="flex items-center gap-1">
+                <RepeatIcon className="size-4 text-icon-primary" />
+                <span className="text-xs-regular text-default">
+                  {formatFrequencyToKorean(task.frequency)}
+                </span>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
     );
   }
 );

--- a/src/components/task/TaskCard.tsx
+++ b/src/components/task/TaskCard.tsx
@@ -27,12 +27,15 @@ const TaskCard = forwardRef<HTMLDivElement, TaskCardProps>(
       setIsTaskUpdateFormShow,
       setIsTaskDeleteDialogOpen,
       setSelectedTask,
+      setTaskDetailModalOpen,
     } = useTaskStore();
 
     const handleClickDropdownUpdate = (
       e?: React.MouseEvent<HTMLButtonElement, MouseEvent>
     ) => {
       e?.stopPropagation();
+      setSelectedTask(task);
+      setTaskDetailModalOpen(true);
       setIsTaskUpdateFormShow(true);
     };
 

--- a/src/components/task/Tasks.tsx
+++ b/src/components/task/Tasks.tsx
@@ -5,7 +5,6 @@ import { Task } from '@/types/tasks.types';
 import { cn } from '@/utils/tailwind/cn';
 import { Loader2 } from 'lucide-react';
 import { useRouter } from 'next/router';
-import { useState } from 'react';
 import TaskCard from './TaskCard';
 import TaskListSelector from './TaskListSelector';
 import TaskDetailModal from './taskDetail/TaskDetailModal';
@@ -20,6 +19,8 @@ function Tasks({ team, isTeamLoading, isTeamFetched }: TasksProps) {
   const { id } = useRouter().query;
   const {
     selectedDate,
+    selectedTask,
+    setSelectedTask,
     selectedTaskList,
     taskDetailModalOpen,
     setTaskDetailModalOpen,
@@ -30,7 +31,6 @@ function Tasks({ team, isTeamLoading, isTeamFetched }: TasksProps) {
     date: new Date(selectedDate).toLocaleDateString('ko-KR'),
   });
   const { mutate: updateTaskStatus } = useUpdateTaskStatus();
-  const [selectedTask, setSelectedTask] = useState<Task | null>(null);
 
   const handleCheckBoxChange = (taskId: number, done: boolean) => {
     updateTaskStatus({

--- a/src/pages/[id]/tasks/index.tsx
+++ b/src/pages/[id]/tasks/index.tsx
@@ -1,6 +1,7 @@
 import { DatePicker } from '@/components/common/DatePicker';
 import AddTaskListModal from '@/components/task/AddTaskListModal';
 import AddTaskModal from '@/components/task/AddTaskModal';
+import DeleteTaskModal from '@/components/task/DeleteTaskModal';
 import Tasks from '@/components/task/Tasks';
 import { useTeamQuery } from '@/queries/groups.queries';
 import { useTaskStore } from '@/store/useTaskStore';
@@ -41,6 +42,7 @@ export default function TaskPage() {
         isTeamFetched={isTeamFetched}
       />
       {team?.taskLists.length !== 0 && <AddTaskModal />}
+      <DeleteTaskModal />
     </>
   );
 }

--- a/src/store/useTaskStore.ts
+++ b/src/store/useTaskStore.ts
@@ -1,10 +1,12 @@
 import { TaskList } from '@/types/tasklist.types';
+import { Task } from '@/types/tasks.types';
 import { create } from 'zustand';
 import { combine } from 'zustand/middleware';
 import { immer } from 'zustand/middleware/immer';
 
 export type TaskState = {
   selectedDate: Date;
+  selectedTask: Task | null;
   selectedTaskList: TaskList | null;
   taskDetailModalOpen: boolean;
   isTaskUpdateFormShow: boolean;
@@ -13,6 +15,7 @@ export type TaskState = {
 
 export type TaskActions = {
   setSelectedDate: (date: Date) => void;
+  setSelectedTask: (task: Task) => void;
   setSelectedTaskList: (taskList: TaskList) => void;
   setTaskDetailModalOpen: (open: boolean) => void;
   setIsTaskUpdateFormShow: (show: boolean) => void;
@@ -21,6 +24,7 @@ export type TaskActions = {
 
 const initialState: TaskState = {
   selectedDate: new Date(),
+  selectedTask: null,
   selectedTaskList: null,
   taskDetailModalOpen: false,
   isTaskUpdateFormShow: false,
@@ -33,6 +37,11 @@ export const useTaskStore = create(
       setSelectedDate: (date: Date) => {
         set((state) => {
           state.selectedDate = date;
+        });
+      },
+      setSelectedTask: (task: Task | null) => {
+        set((state) => {
+          state.selectedTask = task;
         });
       },
       setSelectedTaskList: (taskList: TaskList) => {


### PR DESCRIPTION
### 작업 내용

- 할일삭제 모달 위치를 수정했습니다.

버그 설명
할일 목록 페이지 할일 삭제 모달의 위치가 정상적인 위치에서 나오지 않고 있습니다.

재현 방법
문제 재현 단계:
1. 할일 목록페이지로 이동
2. 할일 더보기 클릭 후 삭제하기 을(를) 클릭
4. 오류 확인

예상된 동작
삭제 확인 모달이 z-index 상위에 나와야 합니다.

### 스크린샷(선택)
![image](https://github.com/user-attachments/assets/1bfc9590-e288-412a-8767-480b07514a9c)


### 관련 이슈

- resolves #124 
