### PR TITLE
Fix/128개선-버그-팀-페이지-모바일-환경-버그-수정

### DIFF
--- a/src/components/TaskList/TaskLists.tsx
+++ b/src/components/TaskList/TaskLists.tsx
@@ -59,12 +59,14 @@ function TaskItem({ taskList, taskListColor, isMember }: TaskItemProps) {
         className={`absolute bottom-0 left-0 top-0 
           z-0  w-[0.8rem] rounded-l-xl ${taskListColor}`}
       />
-      <span className="text-md-medium">{taskList.name}</span>
+      <span className="truncate text-md-medium">{taskList.name}</span>
       <div className="flex h-[1.5625rem] gap-1">
-        <Badge
-          count={taskList.tasks.filter((task) => task.doneAt).length}
-          left={taskList.tasks.length}
-        />
+        <div className="w-[3.5rem]">
+          <Badge
+            count={taskList.tasks.filter((task) => task.doneAt).length}
+            left={taskList.tasks.length}
+          />
+        </div>
         {isMember && (
           <Dropdown
             dropdownStyle="transform translate-x-[-105%]
@@ -72,7 +74,7 @@ function TaskItem({ taskList, taskListColor, isMember }: TaskItemProps) {
             trigger={
               <button
                 type="button"
-                className="rounded-lg hover:bg-tertiary"
+                className="w-[20px] rounded-lg hover:bg-tertiary"
                 onClick={(e) => e.stopPropagation()}
               >
                 <Image

--- a/src/components/TaskList/TaskLists.tsx
+++ b/src/components/TaskList/TaskLists.tsx
@@ -61,7 +61,7 @@ function TaskItem({ taskList, taskListColor, isMember }: TaskItemProps) {
       />
       <span className="truncate text-md-medium">{taskList.name}</span>
       <div className="flex h-[1.5625rem] gap-1">
-        <div className="w-[3.5rem]">
+        <div className="w-[3.8rem]">
           <Badge
             count={taskList.tasks.filter((task) => task.doneAt).length}
             left={taskList.tasks.length}

--- a/src/pages/[id]/index.tsx
+++ b/src/pages/[id]/index.tsx
@@ -43,6 +43,8 @@ export default function TeamPage() {
   const [isAdmin, setIsAdmin] = useState(false);
   const [isMember, setIsMember] = useState(false);
   const [isDeleteTeamModal, setIsDeleteTeamModal] = useState(false);
+  const deleteTeam = useDeleteTeamMutation();
+  const { toast } = useToast();
   useRedirect();
 
   useEffect(() => {
@@ -58,9 +60,6 @@ export default function TeamPage() {
       }
     }
   }, [user, group]);
-
-  const deleteTeam = useDeleteTeamMutation();
-  const { toast } = useToast();
 
   if (!isFetched) {
     return (
@@ -112,7 +111,18 @@ export default function TeamPage() {
         className="relative flex h-[4rem] items-center
      justify-start rounded-xl border border-primary bg-secondary pl-5 pr-20"
       >
-        <p className="truncate text-xl-bold">{group?.name}</p>
+        <div
+          className="flex h-[47px] min-w-[47px]
+         items-center overflow-hidden rounded-full border-2 border-primary"
+        >
+          <Image
+            src={group?.image || '/icons/BaseTeam_Icon.svg'}
+            alt="team-profile"
+            width={43}
+            height={43}
+          />
+        </div>
+        <p className="truncate pl-3 text-xl-bold">{group?.name}</p>
         <div className="absolute right-5 flex items-center gap-7">
           <Image
             src="/images/Thumbnail_team.svg"
@@ -216,7 +226,7 @@ export default function TeamPage() {
               삭제된 할 팀은 복구할 수 없습니다.
             </DialogDescription>
           </DialogHeader>
-          <DialogFooter>
+          <DialogFooter className="mob:gap-1">
             <Button
               buttonStyle={ButtonStyle.Box}
               textColor={TextColor.Gray}

--- a/src/queries/groups.queries.ts
+++ b/src/queries/groups.queries.ts
@@ -89,6 +89,9 @@ export const useTeamMutation = () => {
       queryClient.invalidateQueries({
         queryKey: usersQueryKeys.memberships(),
       });
+      queryClient.invalidateQueries({
+        queryKey: usersQueryKeys.user(),
+      });
       toast({
         title: '해당 팀을 생성했습니다.',
       });


### PR DESCRIPTION
### 작업 내용

- 모바일 환경에서 팀 페이지 버그들을 수정했습니다.
- 할일 목록에서 목록 제목이 길어지면 ui가 망가지는 현상 수정
- 팀페이지 첫 생성시 할일 추가하기 버튼이 안보이는 등 관리자 모드로 보이지 않는 버그 수정
- 팀 페이지에 팀 프로필 UI 추가

### 스크린샷(선택)
<img width="372" alt="image" src="https://github.com/user-attachments/assets/88b99476-4b96-4802-b703-832f317ad0b9">

### 관련 이슈
- resolves #128 