### PR TITLE
fix : 로그아웃 시 401 에러 방지를 위해 useGetUser를 useAuthStore로 교체 to Main

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,13 +1,13 @@
-import { useGetUser } from '@/queries/users.queries';
+import { useAuthStore } from '@/store/useAuthStore';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
 
 export default function Home() {
   const router = useRouter();
-  const { data } = useGetUser();
+  const { user } = useAuthStore();
 
   const handlePageChange = () => {
-    if (!data) {
+    if (!user) {
       router.push('/signin');
     } else {
       router.push('/withoutteam');


### PR DESCRIPTION
### 작업 내용

- 로그아웃 시 401 에러 방지를 위해 useGetUser를 useAuthStore로 교체

### 스크린샷(선택)

### 리뷰 요구사항(선택)

- 리뷰어에게 특별히 알려주거나 요청하고 싶은 싶은 사항이 있으면 적어주세요.

### 관련 이슈

- resolves #

